### PR TITLE
feat(lite): minimal read-only uptime navigator

### DIFF
--- a/.github/workflows/lite-image.yml
+++ b/.github/workflows/lite-image.yml
@@ -1,0 +1,87 @@
+name: Publish uptime-navigator-lite
+
+on:
+  push:
+    tags:
+      - 'lite-v*'
+    branches:
+      - main
+    paths:
+      - 'lite/**'
+      - '.github/workflows/lite-image.yml'
+  pull_request:
+    paths:
+      - 'lite/**'
+      - '.github/workflows/lite-image.yml'
+  workflow_dispatch:
+    inputs:
+      docker_tag_prefix:
+        description: "Docker tag prefix (e.g. adhoc-test)"
+        required: true
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: o1-labs/uptime-navigator-lite
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    name: Build and push image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Compute tag
+        id: tag
+        run: |
+          SHORT_SHA=$(echo "$GITHUB_SHA" | cut -c1-7)
+          case "${{ github.event_name }}" in
+            push)
+              if [[ "$GITHUB_REF" == refs/tags/lite-v* ]]; then
+                TAG="${GITHUB_REF#refs/tags/lite-}"
+              else
+                TAG="main-${SHORT_SHA}"
+              fi
+              PUSH=true
+              ;;
+            pull_request)
+              TAG="pr-${{ github.event.pull_request.number }}-${SHORT_SHA}"
+              PUSH=false
+              ;;
+            workflow_dispatch)
+              PREFIX="${{ inputs.docker_tag_prefix }}"
+              BRANCH=$(echo "${GITHUB_REF##*/}" | tr '[:upper:]' '[:lower:]')
+              TAG="${PREFIX}-${BRANCH}-${SHORT_SHA}"
+              PUSH=true
+              ;;
+          esac
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "push=$PUSH" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        if: steps.tag.outputs.push == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build (and conditionally push)
+        uses: docker/build-push-action@v5
+        with:
+          context: ./lite
+          push: ${{ steps.tag.outputs.push }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,12 @@
 
 .env
 env.sh
+
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+
+# macOS
+.DS_Store

--- a/lite/Dockerfile
+++ b/lite/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      libpq5 ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY api/requirements.txt /app/api/requirements.txt
+RUN pip install --no-cache-dir -r /app/api/requirements.txt
+
+COPY api/ /app/api/
+COPY web/ /app/web/
+
+WORKDIR /app/api
+
+EXPOSE 8080
+
+CMD ["gunicorn", "--bind", "0.0.0.0:8080", "--workers", "2", "--threads", "4", "--access-logfile", "-", "app:app"]

--- a/lite/README.md
+++ b/lite/README.md
@@ -1,0 +1,46 @@
+# uptime-navigator-lite
+
+A minimal read-only navigator over the `submissions` table written by
+`uptime-service-backend`. Single container: Flask API + static HTML/JS,
+served on port 8080.
+
+## Endpoints
+
+| Path | Purpose |
+|---|---|
+| `GET /` | Static page (`web/index.html`) |
+| `GET /api/submitters` | Distinct submitters with submission counts, last/first seen, valid/invalid counters |
+| `GET /api/submitter/<pubkey>` | Most recent 100 submissions for one BP |
+| `GET /api/summary` | Daily counts per submitter |
+| `GET /healthz` | DB-reachable ping |
+
+## Environment
+
+| Variable | Required | Notes |
+|---|---|---|
+| `POSTGRES_HOST` | yes | |
+| `POSTGRES_PORT` | no | defaults to `5432` |
+| `POSTGRES_DB` | yes | |
+| `POSTGRES_USER` | yes | |
+| `POSTGRES_PASSWORD` | yes | |
+| `POSTGRES_SSLMODE` | no | defaults to `disable` |
+| `WHITELIST` | no | comma-separated submitter pubkeys; when set, all queries filter to this set |
+
+## Local smoke test
+
+```bash
+docker build -t uptime-navigator-lite:dev .
+docker run --rm -p 8080:8080 \
+  -e POSTGRES_HOST=host.docker.internal \
+  -e POSTGRES_DB=coordinator \
+  -e POSTGRES_USER=o1labs \
+  -e POSTGRES_PASSWORD=secret \
+  uptime-navigator-lite:dev
+curl localhost:8080/healthz
+curl localhost:8080/api/submitters
+```
+
+## Published image
+
+`ghcr.io/o1-labs/uptime-navigator-lite:<tag>` — pushed by
+`.github/workflows/lite-image.yml` on tag push or `workflow_dispatch`.

--- a/lite/api/app.py
+++ b/lite/api/app.py
@@ -1,0 +1,127 @@
+"""Minimal uptime-navigator API.
+
+Reads directly from the `submissions` table populated by uptime-service-backend
+and exposes a small read-only HTTP surface. Optional comma-separated WHITELIST
+env var filters every query to a set of submitter public keys.
+"""
+
+import os
+
+import psycopg2
+from flask import Flask, jsonify, send_from_directory
+from psycopg2.extras import RealDictCursor
+
+WEB_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "web")
+
+app = Flask(__name__, static_folder=WEB_ROOT, static_url_path="")
+
+
+def get_conn():
+    return psycopg2.connect(
+        host=os.environ["POSTGRES_HOST"],
+        port=os.environ.get("POSTGRES_PORT", "5432"),
+        dbname=os.environ["POSTGRES_DB"],
+        user=os.environ["POSTGRES_USER"],
+        password=os.environ["POSTGRES_PASSWORD"],
+        sslmode=os.environ.get("POSTGRES_SSLMODE", "disable"),
+        connect_timeout=int(os.environ.get("POSTGRES_CONNECT_TIMEOUT", "5")),
+    )
+
+
+def whitelist():
+    raw = os.environ.get("WHITELIST", "").strip()
+    if not raw:
+        return None
+    return [k.strip() for k in raw.split(",") if k.strip()]
+
+
+def _row_dates_iso(rows, *fields):
+    for r in rows:
+        for f in fields:
+            if r.get(f) is not None:
+                r[f] = r[f].isoformat()
+    return rows
+
+
+@app.get("/healthz")
+def healthz():
+    try:
+        with get_conn() as conn, conn.cursor() as cur:
+            cur.execute("SELECT 1")
+        return jsonify(status="ok"), 200
+    except Exception as e:
+        return jsonify(status="error", error=str(e)), 500
+
+
+@app.get("/api/submitters")
+def submitters():
+    keys = whitelist()
+    where = "WHERE 1=1"
+    params = []
+    if keys is not None:
+        where += " AND submitter = ANY(%s)"
+        params.append(keys)
+    sql = f"""
+        SELECT submitter,
+               COUNT(*) AS submissions,
+               MAX(submitted_at) AS last_seen,
+               MIN(submitted_at) AS first_seen,
+               COUNT(*) FILTER (WHERE validation_error IS NULL) AS valid,
+               COUNT(*) FILTER (WHERE validation_error IS NOT NULL) AS invalid
+        FROM submissions
+        {where}
+        GROUP BY submitter
+        ORDER BY submissions DESC
+    """
+    with get_conn() as conn, conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(sql, params)
+        rows = cur.fetchall()
+    return jsonify(_row_dates_iso(rows, "last_seen", "first_seen"))
+
+
+@app.get("/api/submitter/<pubkey>")
+def submitter(pubkey):
+    keys = whitelist()
+    if keys is not None and pubkey not in keys:
+        return jsonify(error="not in whitelist"), 404
+    sql = """
+        SELECT id, submitted_at, block_hash, state_hash, parent,
+               height, slot, validation_error, verified, remote_addr,
+               peer_id, built_with_commit_sha
+        FROM submissions
+        WHERE submitter = %s
+        ORDER BY submitted_at DESC
+        LIMIT 100
+    """
+    with get_conn() as conn, conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(sql, (pubkey,))
+        rows = cur.fetchall()
+    return jsonify(_row_dates_iso(rows, "submitted_at"))
+
+
+@app.get("/api/summary")
+def summary():
+    keys = whitelist()
+    where = "WHERE 1=1"
+    params = []
+    if keys is not None:
+        where += " AND submitter = ANY(%s)"
+        params.append(keys)
+    sql = f"""
+        SELECT submitted_at_date::text AS day,
+               submitter,
+               COUNT(*) AS submissions
+        FROM submissions
+        {where}
+        GROUP BY day, submitter
+        ORDER BY day DESC, submissions DESC
+    """
+    with get_conn() as conn, conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(sql, params)
+        rows = cur.fetchall()
+    return jsonify(rows)
+
+
+@app.get("/")
+def root():
+    return send_from_directory(WEB_ROOT, "index.html")

--- a/lite/api/requirements.txt
+++ b/lite/api/requirements.txt
@@ -1,0 +1,3 @@
+flask==3.0.3
+psycopg2-binary==2.9.9
+gunicorn==22.0.0

--- a/lite/web/app.js
+++ b/lite/web/app.js
@@ -1,0 +1,111 @@
+const $ = (s) => document.querySelector(s);
+const tbody = $("#submitters tbody");
+const detailBody = $("#detail-rows tbody");
+
+let cached = [];
+let sortField = "submissions";
+let sortDir = -1;
+
+async function fetchJSON(url) {
+  const r = await fetch(url);
+  if (!r.ok) throw new Error(`${url}: HTTP ${r.status}`);
+  return r.json();
+}
+
+function fmtDate(s) {
+  if (!s) return "—";
+  return new Date(s).toLocaleString();
+}
+
+function truncate(s, n = 12) {
+  if (!s) return "";
+  return s.length <= n ? s : `${s.slice(0, n)}…`;
+}
+
+function renderList() {
+  const sorted = [...cached].sort((a, b) => {
+    const av = a[sortField], bv = b[sortField];
+    if (av === bv) return 0;
+    if (av == null) return 1;
+    if (bv == null) return -1;
+    return av < bv ? -sortDir : sortDir;
+  });
+  tbody.innerHTML = "";
+  for (const row of sorted) {
+    const tr = document.createElement("tr");
+    tr.innerHTML = `
+      <td><a href="#" data-pk="${row.submitter}"><code>${truncate(row.submitter, 24)}</code></a></td>
+      <td class="num">${row.submissions}</td>
+      <td class="num">${row.valid}</td>
+      <td class="num invalid">${row.invalid}</td>
+      <td>${fmtDate(row.last_seen)}</td>
+      <td>${fmtDate(row.first_seen)}</td>
+    `;
+    tbody.appendChild(tr);
+  }
+  $("#submitter-count").textContent = cached.length;
+  $("#empty").hidden = cached.length !== 0;
+}
+
+async function loadList() {
+  $("#error").hidden = true;
+  try {
+    cached = await fetchJSON("/api/submitters");
+    renderList();
+    $("#refreshed").textContent = new Date().toLocaleTimeString();
+  } catch (e) {
+    $("#error").hidden = false;
+    $("#error").textContent = `Error loading submitters: ${e.message}`;
+  }
+}
+
+async function showDetail(pubkey) {
+  detailBody.innerHTML = "";
+  $("#detail-pubkey").textContent = pubkey;
+  $("#detail").hidden = false;
+  $("#list").hidden = true;
+  try {
+    const rows = await fetchJSON(`/api/submitter/${encodeURIComponent(pubkey)}`);
+    for (const r of rows) {
+      const tr = document.createElement("tr");
+      tr.innerHTML = `
+        <td>${fmtDate(r.submitted_at)}</td>
+        <td class="num">${r.height ?? ""}</td>
+        <td class="num">${r.slot ?? ""}</td>
+        <td><code>${truncate(r.block_hash || "", 20)}</code></td>
+        <td>${r.validation_error || ""}</td>
+      `;
+      detailBody.appendChild(tr);
+    }
+  } catch (e) {
+    detailBody.innerHTML = `<tr><td colspan="5">Error: ${e.message}</td></tr>`;
+  }
+}
+
+function hideDetail() {
+  $("#detail").hidden = true;
+  $("#list").hidden = false;
+}
+
+tbody.addEventListener("click", (e) => {
+  const link = e.target.closest("a[data-pk]");
+  if (!link) return;
+  e.preventDefault();
+  showDetail(link.dataset.pk);
+});
+
+$("#back").addEventListener("click", hideDetail);
+$("#refresh").addEventListener("click", loadList);
+
+document.querySelectorAll("#submitters thead th").forEach((th) => {
+  th.addEventListener("click", () => {
+    const field = th.dataset.sort;
+    if (!field) return;
+    if (sortField === field) sortDir = -sortDir;
+    else { sortField = field; sortDir = -1; }
+    renderList();
+  });
+});
+
+loadList();
+setInterval(loadList, 30000);

--- a/lite/web/index.html
+++ b/lite/web/index.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Uptime Navigator</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <header>
+    <h1>Uptime Navigator</h1>
+    <div class="meta">
+      <span id="submitter-count">—</span> submitters &middot;
+      refreshed <span id="refreshed">—</span>
+      <button id="refresh" type="button">Refresh</button>
+    </div>
+  </header>
+
+  <main>
+    <section id="list">
+      <table id="submitters">
+        <thead>
+          <tr>
+            <th data-sort="submitter">Submitter</th>
+            <th data-sort="submissions" class="num">Submissions</th>
+            <th data-sort="valid" class="num">Valid</th>
+            <th data-sort="invalid" class="num">Invalid</th>
+            <th data-sort="last_seen">Last seen</th>
+            <th data-sort="first_seen">First seen</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+      <p id="empty" hidden>No submissions yet.</p>
+      <p id="error" hidden></p>
+    </section>
+
+    <section id="detail" hidden>
+      <button id="back" type="button">&laquo; Back</button>
+      <h2><code id="detail-pubkey"></code></h2>
+      <table id="detail-rows">
+        <thead>
+          <tr>
+            <th>Submitted at</th>
+            <th>Height</th>
+            <th>Slot</th>
+            <th>Block hash</th>
+            <th>Validation error</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  </main>
+
+  <script src="/app.js"></script>
+</body>
+</html>

--- a/lite/web/style.css
+++ b/lite/web/style.css
@@ -1,0 +1,94 @@
+:root {
+  --fg: #1c1c1c;
+  --bg: #fafafa;
+  --muted: #6b6b6b;
+  --border: #e4e4e4;
+  --accent: #2c5cdd;
+  --bad: #c0392b;
+  --good: #1e8449;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  font-size: 14px;
+  color: var(--fg);
+  background: var(--bg);
+}
+
+header {
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--border);
+  background: white;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+header h1 { margin: 0; font-size: 18px; font-weight: 600; }
+
+.meta { color: var(--muted); font-size: 13px; }
+.meta button {
+  margin-left: 8px;
+  padding: 4px 10px;
+  border: 1px solid var(--border);
+  background: white;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.meta button:hover { border-color: var(--accent); color: var(--accent); }
+
+main { padding: 16px 24px; }
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  background: white;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+th, td {
+  padding: 8px 12px;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  font-variant-numeric: tabular-nums;
+}
+
+th {
+  background: #f4f4f4;
+  font-weight: 600;
+  cursor: pointer;
+  user-select: none;
+}
+th:hover { background: #ececec; }
+
+td.num, th.num { text-align: right; }
+td.invalid { color: var(--bad); }
+
+code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+}
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+#error { color: var(--bad); }
+#empty { color: var(--muted); }
+
+#back {
+  margin-bottom: 12px;
+  padding: 4px 10px;
+  border: 1px solid var(--border);
+  background: white;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+#detail h2 { margin: 0 0 12px 0; word-break: break-all; font-size: 14px; }


### PR DESCRIPTION
Adds lite/ subtree with a Flask API + vanilla JS frontend that reads                                                                                                                                                                                      
  directly from the uptime-service-backend submissions table. Single                                                                                                                                                                                          
  container (gunicorn :8080). Optional WHITELIST env var filters all
  queries to a set of submitter pubkeys. No AWS, no Sheets.                                                                                                                                                                                                   
                                                                                                                                                                                                                                                            
  CI: .github/workflows/lite-image.yml publishes                                                                                                                                                                                                              
  ghcr.io/o1-labs/uptime-navigator-lite on push to main / lite-v* tags                                                                                                                                                                                      
  / matching PRs.