### PR TITLE
docs: refresh READMEs and add AGENTS.md for agentic-era onboarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ __pycache__/
 
 # macOS
 .DS_Store
+**/.DS_Store
+
+# Session-local agent state
+.memsearch/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,84 @@
+# AGENTS.md
+
+Guidance for AI coding agents (Codex, Cursor, Aider, Jules, Claude Code, …) working in this repository. Humans should start with [`README.md`](./README.md); agents should start here.
+
+Claude Code users: [`CLAUDE.md`](./CLAUDE.md) carries the same information in the format Claude expects. The two files are kept in sync — pick whichever your tooling reads automatically.
+
+## What this repo is
+
+A two-service containerised application that surfaces Mina Protocol's Delegation Program SNARK-work uptime data:
+
+- **`web/`** — PHP 8 + Apache frontend, public leaderboard UI. Queries Postgres directly.
+- **`api/`** — Flask REST API with Swagger UI. Independent of `web/`.
+
+Both connect to the same external PostgreSQL database. There is **no** call from `web/` to `api/`.
+
+## Code map
+
+```
+api/
+  minanet_app/flask_api.py    ← all routes; start here for API changes
+  minanet_app/config.py       ← env → BaseConfig
+  minanet_app/db_health.py    ← connection retry + readiness logic
+  minanet_app/api_spec*.yml   ← Swagger response schemas (edit these, not docstrings)
+  diagnose_connection.py      ← standalone DB diagnostic
+web/
+  index.php                   ← page shell
+  showDataForTabOne.php       ← leaderboard table renderer
+  getPageDataForSnark.php     ← AJAX data fetch
+  connectionsnark.php         ← PDO connection
+  config.php                  ← env → PHP config (URLs)
+Justfile                      ← canonical build/run commands
+docker-compose.yaml           ← service definitions, env_file: .env
+.env.example                  ← every supported env var, with defaults
+.github/workflows/publish.yml ← builds + pushes both images to ghcr.io on tag
+```
+
+## How to run it
+
+```bash
+cp .env.example .env       # fill in DB credentials
+just build-all
+just launch-all            # web on :80, api on :5000
+```
+
+Per-service recipes: `build-web`, `build-api`, `launch-web`, `launch-api`, `destroy-web`, `destroy-api`, `destroy-all`. Run `just` (no args) to list them.
+
+There is no language-level test suite in this repo. To verify a change end-to-end:
+
+1. `just build-<component>` — confirms Docker build succeeds.
+2. `just launch-<component>` — confirms the container starts.
+3. For the API: `curl localhost:5000/health/ready` should return `200` with `status: ready`.
+4. For the web: open `http://localhost:80` and confirm the leaderboard renders.
+
+If you can't run Docker in your sandbox, say so explicitly in your report rather than claiming success.
+
+## Conventions
+
+- **Environment-driven config.** Both services read everything from env vars. Never hard-code hosts, ports, credentials, or URLs — add to [`.env.example`](./.env.example) and the relevant config file ([`api/minanet_app/config.py`](./api/minanet_app/config.py) or [`web/config.php`](./web/config.php)).
+- **`just` is the canonical interface.** When you add a new buildable artefact or runnable service, add a recipe to [`Justfile`](./Justfile).
+- **Pinned dependencies.** [`api/requirements.txt`](./api/requirements.txt) pins exact versions. Upgrade deliberately and as a single focused change.
+- **Swagger schemas live in YAML.** Add or edit response shapes in [`api/minanet_app/api_spec*.yml`](./api/minanet_app/) and reference them with `@swag_from(...)` — don't inline schemas in `flask_api.py`.
+- **Health endpoints are load-bearing.** `/health` and `/health/ready` are consumed by container orchestrators. Don't rename or change their response contract without coordinating a deployment update.
+
+## Gotchas
+
+- **`LOGGING_LOCATION` default crashes in containers.** The default `./application.log` may be unwritable. For containerised deployments set `LOGGING_LOCATION=""` to switch to console-only logging.
+- **Web does *not* call the API.** Changing an API response shape does not affect the leaderboard UI — and vice versa. Make sure your change targets the right component.
+- **`IGNORE_APPLICATION_STATUS=1` is a test-mode flag for `web/` only.** Setting it in production bypasses the `application_status = true` filter and exposes applicants who have not been accepted. The API has no equivalent flag.
+- **Image publish on tag push.** [`/.github/workflows/publish.yml`](./.github/workflows/publish.yml) builds and pushes to `ghcr.io` whenever a tag is pushed. Tag deliberately.
+- **The web image bakes PHP files at build time** — they're not bind-mounted. Rebuild after editing.
+
+## What not to touch without asking
+
+- `.github/workflows/publish.yml` — affects every consumer of the published images.
+- `Dockerfile` base image pins (`python:3.12`, `php:apache`) — drift here cascades into runtime behaviour and dependency compatibility.
+- Database query logic in [`web/showDataForTabOne.php`](./web/showDataForTabOne.php) and [`web/getPageDataForSnark.php`](./web/getPageDataForSnark.php) — small changes can silently exclude or duplicate participants.
+- Swagger `basePath` / `host` in [`api/minanet_app/flask_api.py`](./api/minanet_app/flask_api.py) — downstream tooling depends on the published API surface.
+
+## When in doubt
+
+- Read [`README.md`](./README.md) for the human framing.
+- Read [`api/README.md`](./api/README.md) and [`web/README.md`](./web/README.md) for component-level detail (env vars, endpoints, troubleshooting).
+- Check [`.env.example`](./.env.example) — it is the most up-to-date catalogue of supported environment variables.
+- For Claude-Code-specific guidance (sessions, planning, memory): [`CLAUDE.md`](./CLAUDE.md).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,49 @@
-# Delegation-program-leaderboard
+# Delegation Program Leaderboard
 
- - [Web](/web/README.md)
- - [API](/api/README.md)
+Containerized leaderboard for Mina Protocol's Delegation Program. It surfaces SNARK-work uptime data from the Delegation Program PostgreSQL database, both as a public web page and as a documented REST API.
+
+## Components
+
+| Path | Stack | Port | Purpose |
+|------|-------|------|---------|
+| [`/web`](./web/README.md) | PHP 8 + Apache + Bootstrap 4 | `80` | Public leaderboard UI (queries Postgres directly). |
+| [`/api`](./api/README.md) | Python 3.12 + Flask + Flasgger | `5000` | REST API + Swagger UI for uptime scores. |
+
+Both containers connect **independently** to the same PostgreSQL database — the web frontend does *not* call the API.
+
+## Quick start
+
+```bash
+cp .env.example .env        # fill in DB credentials
+just build-all              # build both images
+just launch-all             # start web on :80 and api on :5000
+```
+
+- Web UI: <http://localhost:80>
+- Swagger UI: <http://localhost:5000/apidocs/>
+- API readiness probe: <http://localhost:5000/health/ready>
+
+Run `just` with no arguments to list every recipe.
+
+## Repository layout
+
+```
+.
+├── README.md              ← you are here
+├── AGENTS.md              ← entry point for AI agents (Codex, Cursor, Aider, …)
+├── CLAUDE.md              ← Claude Code-specific guidance
+├── Justfile               ← canonical build/run commands
+├── docker-compose.yaml    ← service definitions
+├── .env.example           ← all supported environment variables
+├── api/                   ← Flask API (see api/README.md)
+├── web/                   ← PHP frontend (see web/README.md)
+└── .github/workflows/     ← image publishing to ghcr.io on tag push
+```
+
+## For AI agents
+
+Read [`AGENTS.md`](./AGENTS.md) first — it lists entry points, run/test commands, and the things you should *not* change without asking. Claude Code users also have [`CLAUDE.md`](./CLAUDE.md) with the same information formatted for Claude.
+
+## Deployment
+
+Tagged commits trigger `.github/workflows/publish.yml`, which builds and pushes both images to GitHub Container Registry (`ghcr.io`). Manual runs accept a `docker_tag_prefix` input for ad-hoc tags.

--- a/api/README.md
+++ b/api/README.md
@@ -1,61 +1,132 @@
-# Delegation Program Leaderboard API
+# Delegation Program Leaderboard — API
 
-An API to browse Uptime Service database.
+Flask REST API exposing the Mina Delegation Program SNARK-work uptime database. Ships with Swagger UI, response caching, Kubernetes-style health probes, and connection-retry logic.
 
-## Description
+## Stack
 
-Flask python application serving API endpoints to browse Delegation Program Uptime Service database.
+- Python 3.12 on `python:3.12`
+- Flask 2.2, Flask-Caching, Flasgger (Swagger 2.0)
+- `psycopg2` against PostgreSQL
+- Health/diagnostics modules for container orchestration
 
-## Prerequisites
+## File map
 
-- [Docker](https://docs.docker.com/get-docker/)
-- [Docker Compose](https://docs.docker.com/compose/install/)
-- just(optional)
+| File | Role |
+|------|------|
+| [`minanet_app/flask_api.py`](./minanet_app/flask_api.py) | App entry point — all routes, Swagger config, error handlers. |
+| [`minanet_app/config.py`](./minanet_app/config.py) | `BaseConfig` — pulls everything from env. |
+| [`minanet_app/db_health.py`](./minanet_app/db_health.py) | Connection retry + health-check logic. |
+| [`minanet_app/logger_util.py`](./minanet_app/logger_util.py) | Logger setup (file or console). |
+| [`minanet_app/entrypoint`](./minanet_app/entrypoint) | Container entrypoint (`python flask_api.py`). |
+| [`minanet_app/api_spec*.yml`](./minanet_app/) | Swagger response schemas referenced from route docstrings. |
+| [`diagnose_connection.py`](./diagnose_connection.py) | Standalone DB connectivity diagnostic (DNS → TCP → auth → query). |
+| [`Dockerfile`](./Dockerfile) | Build recipe. |
+| [`requirements.txt`](./requirements.txt) | Pinned Python dependencies. |
+
+## Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/health` | Liveness probe. Always 200 if Flask is up. |
+| GET | `/health/ready` | Readiness probe. 200 only if DB is reachable. |
+| GET | `/health/debug` | Verbose diagnostics. Available **only** when `DEBUG=true`. |
+| GET | `/uptimescore/` | Latest uptime scores for all producers. |
+| GET | `/uptimescore/<pubkey>` | Latest score for a single producer. |
+| GET | `/uptimescore/<pubkey>/<dataType>/` | Historic series for a producer. |
+| GET | `/uptimescore/<pubkey>/<dataType>/<scoreAt>/` | Score at a specific timestamp. |
+| GET | `/apidocs/` | Swagger UI. |
+
+Routes are defined in [`minanet_app/flask_api.py`](./minanet_app/flask_api.py) (see lines 70, 82, 115, 252–255).
 
 ## Configuration
 
-The following environment variables need to be set to successfully launch the docker container:
+Copy the root [`.env.example`](../.env.example) to `.env` and edit the values:
 
 ```bash
-# Delegation Program postgres db details  
-SNARK_HOST=
-SNARK_PORT=
-SNARK_USER=
-SNARK_PASSWORD=
-SNARK_DB=
-# API host:port details to start listening to 
-API_HOST=
-API_PORT=
-SWAGGER_HOST=
-
-# Misc
-CACHE_TIMEOUT=
-LOGGING_LOCATION=
+cp ../.env.example ../.env
 ```
- 
-## Running locally
 
-This example assumes that you will use `just` to spin up resources using docker-compose executing from the root of the repository
+### Required — database
 
-1. If you have `just` installed, check available just recipes(from the root of git repo). You can inspect recipe definitions in `Justfile`.
+| Variable | Purpose |
+|----------|---------|
+| `SNARK_HOST` | PostgreSQL host. |
+| `SNARK_PORT` | PostgreSQL port (typically `5432`). |
+| `SNARK_USER` | DB user. |
+| `SNARK_PASSWORD` | DB password. |
+| `SNARK_DB` | Database name. |
+
+### Required — server
+
+| Variable | Purpose |
+|----------|---------|
+| `API_HOST` | Bind address (typically `0.0.0.0` in containers). |
+| `API_PORT` | Bind port (typically `5000`). |
+| `SWAGGER_HOST` | Hostname embedded in the Swagger spec (e.g. `localhost:5000` or `uptime.minaprotocol.com`). |
+| `CACHE_TIMEOUT` | Flask-Caching default TTL in seconds. |
+
+### Optional — debug & resilience
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `DEBUG` | `false` | Enables Flask debug mode, pretty-printed JSON, and `/health/debug`. |
+| `LOGGING_LEVEL` | `INFO` | One of `DEBUG`, `INFO`, `WARNING`, `ERROR`. |
+| `LOGGING_LOCATION` | `./application.log` | Log file path. **Set to empty string for console-only logging in containers.** |
+| `DB_CONNECTION_TIMEOUT` | `10` | psycopg2 connect timeout in seconds. |
+| `DB_RETRY_ATTEMPTS` | `3` | Number of connection retries before giving up. |
+
+## Build & run
+
+From the repo root, using `just` (preferred):
 
 ```bash
-$ just
-Available recipes:
-    default     # List available recipes
-    build-api   # Build leaderboard api docker image
-    destroy-api # Stop leaderboard-api
-    launch-api  # Start leaderboard-api locally
-	<..>
+just build-api     # docker build -t leaderboard-api ./api
+just launch-api    # docker-compose up -d leaderboard-api   (binds :5000)
+just destroy-api   # docker-compose down leaderboard-api
 ```
 
-2.  Copy and edit `.env` file
+Then open:
+- Swagger UI: <http://localhost:5000/apidocs/>
+- Readiness: <http://localhost:5000/health/ready>
+
+Without `just`:
+
 ```bash
-$ cp ./api/config_variables.env  ./api/.env
+docker build -t leaderboard-api ./api
+docker run --env-file ../.env --name leaderboard-api -p 5000:5000 -d leaderboard-api
 ```
 
-3. Try running and accessing it
+## Troubleshooting
+
+### Crash on startup with logging errors
+
+The default `LOGGING_LOCATION=./application.log` tries to write to a path that may not exist or be writable inside the container. For containerised deployments, set:
+
 ```bash
-$ just build-api
-$ just launch-api
+LOGGING_LOCATION=""
 ```
+
+This switches the logger to console-only — preferred in Kubernetes / Docker where logs should go to stdout/stderr.
+
+### Database connection failures
+
+1. Hit `/health/ready` — the response payload includes the DB error class and message.
+2. If you need lower-level detail, run the diagnostic script from inside the container or from a host with the same network access:
+
+   ```bash
+   cd api && python diagnose_connection.py
+   ```
+
+   It tests DNS resolution, TCP reachability, authentication, and a minimal `SELECT`.
+
+3. With `DEBUG=true`, `/health/debug` exposes the resolved connection parameters (no password) and recent retry attempts.
+
+### Stale data after a config change
+
+Responses are cached for `CACHE_TIMEOUT` seconds. Either wait it out or restart the container.
+
+## Development notes
+
+- The container `ENTRYPOINT` is [`minanet_app/entrypoint`](./minanet_app/entrypoint), which starts `cron` and `atd`, then execs `flask_api.py`. Cron is currently unused but kept for parity with historic deployments — feel free to slim it down if you're confident no scheduled job depends on it.
+- Swagger response schemas live in separate YAML files (`api_spec*.yml`) and are referenced via `@swag_from(...)` decorators. Edit those rather than inlining schemas in the Python file.
+- Dependencies are pinned in [`requirements.txt`](./requirements.txt). Upgrade deliberately — `Flask 2.x` and `Werkzeug 3.x` have a known ABI mismatch with some plugin versions.

--- a/web/README.md
+++ b/web/README.md
@@ -1,38 +1,92 @@
-# delegation-program-leaderboard
-## Technologies Used 
-***
-> Postgresql,
-> Html 5,
-> Bootstrap 4, 
-> Php 8.0,
-> Docker
-***
+# Delegation Program Leaderboard — Web Frontend
 
-## Installing Docker file
-1. Move terminal to this repo.
-2. Create a config file (i.e. config.env) with below parameters: 
-##### DB_SNARK_HOST=
-##### DB_SNARK_PORT=
-##### DB_SNARK_USER=
-##### DB_SNARK_PWD=
-##### DB_SNARK_DB=
-##### optional test setting
-##### IGNORE_APPLICATION_STATUS=1
+PHP frontend that renders the Mina Delegation Program uptime leaderboard. It queries the Delegation Program PostgreSQL database **directly** — it does not call the sibling API in [`/api`](../api/README.md).
 
-When `IGNORE_APPLICATION_STATUS` is set to `1` the leaderboard will not take into consideration `application_status=true` condition when displaying the results. It is meant to be used in test environments only.
+## Stack
 
-Configure these variables and save the file.
+- PHP 8 on `php:apache` (Debian)
+- Bootstrap 4, vanilla JS, jQuery (assets in [`assets/`](./assets/))
+- `pdo_pgsql` for database access
+- Apache with `ssl` + `rewrite` modules enabled (see [`000-default.conf`](./000-default.conf))
 
-3. Go to the terminal.
-4. Type below commands:
-5. >docker build -t mina-web .
-6. >docker run --env-file ./config.env --name mina-web --restart unless-stopped -p 80:80 -p 443:443 -i -t -d  mina-web
+## File map
 
-This will install all dependancies and start the container. After finishing the process we will opening the browser with `127.0.0.1`
-***
+| File | Role |
+|------|------|
+| [`index.php`](./index.php) | Page shell, tabs, top-level layout. |
+| [`showDataForTabOne.php`](./showDataForTabOne.php) | Renders the leaderboard table. |
+| [`getPageDataForSnark.php`](./getPageDataForSnark.php) | Paginated data fetch for AJAX calls. |
+| [`connectionsnark.php`](./connectionsnark.php) | PDO connection to the Delegation Program DB. |
+| [`config.php`](./config.php) | Reads configurable URLs from environment with defaults. |
+| [`Dockerfile`](./Dockerfile) | Build recipe (php:apache + pdo_pgsql). |
+| [`000-default.conf`](./000-default.conf) | Apache vhost config. |
+| [`php.ini`](./php.ini) | PHP runtime config (copied into `$PHP_INI_DIR/conf.d/`). |
 
-## Note
-After any changes in project you have rebuild the docker file by using 
-`docker build -t mina-web .`
-this command and again run the container .
+## Configuration
 
+All configuration is via environment variables. Copy the root [`.env.example`](../.env.example) to `.env` and edit the values:
+
+```bash
+cp ../.env.example ../.env
+```
+
+### Required — database connection
+
+| Variable | Purpose |
+|----------|---------|
+| `DB_SNARK_HOST` | PostgreSQL host. |
+| `DB_SNARK_PORT` | PostgreSQL port (typically `5432`). |
+| `DB_SNARK_USER` | DB user (read-only role recommended). |
+| `DB_SNARK_PWD` | DB password. |
+| `DB_SNARK_DB` | Database name. |
+
+### Optional — test mode
+
+| Variable | Effect |
+|----------|--------|
+| `IGNORE_APPLICATION_STATUS=1` | Skip the `application_status = true` filter when building the leaderboard. Use **only** in test environments — production leaderboards must keep this unset. |
+
+### Optional — configurable URLs
+
+All have sensible defaults pointing at `minaprotocol.com` / `docs.minaprotocol.com` (see [`config.php`](./config.php)):
+
+- `DELEGATION_PRODUCERS_URL`
+- `DELEGATION_FORM_URL`
+- `DELEGATION_POLICY_URL`
+- `DELEGATION_GUIDELINES_URL`
+- `API_DOCS_URL`
+- `FOUNDATION_PROGRAM_URL`
+- `FOUNDATION_GUIDELINES_URL`
+
+## Build & run
+
+From the repo root, using `just` (preferred):
+
+```bash
+just build-web     # docker build -t leaderboard-web ./web
+just launch-web    # docker-compose up -d leaderboard-web   (binds :80)
+just destroy-web   # docker-compose down leaderboard-web
+```
+
+Without `just`:
+
+```bash
+docker build -t leaderboard-web ./web
+docker run --env-file ../.env --name leaderboard-web -p 80:80 -d leaderboard-web
+```
+
+Then open <http://localhost:80>.
+
+## Common issues
+
+- **Empty leaderboard.** The query filters by `application_status = true AND score IS NOT NULL`. Set `IGNORE_APPLICATION_STATUS=1` to confirm whether the filter is the cause, then verify the underlying rows in the `nodes` table.
+- **`Connection refused` / `could not translate host name`.** Confirm `DB_SNARK_HOST` is reachable from inside the container (try `docker exec -it web getent hosts $DB_SNARK_HOST`).
+- **TLS / mixed-content errors behind a proxy.** Apache has `ssl` and `rewrite` enabled in the image, but TLS termination is expected to happen at the ingress / load balancer in production.
+
+## Rebuilding after changes
+
+The PHP files are baked into the image at build time, not bind-mounted. After editing any file under `web/`, rebuild:
+
+```bash
+just build-web && just launch-web
+```


### PR DESCRIPTION
  - Root README: short index with component table, quick start, repo layout                                                                                                                                                                
  - AGENTS.md (new): code map, run/verify commands, conventions, gotchas                                                                                                                                                                   
  - web/README.md: rewrite to match current code (just, docker-compose, env vars)                                                                                                                                                          
  - api/README.md: add health endpoints, /uptimescore routes, troubleshooting