### PR TITLE
feat(lite): canonical-chain verifier + CI-tested unit suite

### DIFF
--- a/.github/workflows/lite-image.yml
+++ b/.github/workflows/lite-image.yml
@@ -29,8 +29,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  test:
+    name: Lite unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: lite/api/requirements-dev.txt
+
+      - name: Run lite tests
+        run: ./lite/run-tests.sh
+
   build-and-push:
     name: Build and push image
+    needs: test
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 *.py[cod]
 *.egg-info/
 .pytest_cache/
+.venv/
 
 # macOS
 .DS_Store

--- a/lite/api/requirements-dev.txt
+++ b/lite/api/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest==8.3.3
+pytest-mock==3.14.0

--- a/lite/api/requirements.txt
+++ b/lite/api/requirements.txt
@@ -1,3 +1,4 @@
 flask==3.0.3
 psycopg2-binary==2.9.9
 gunicorn==22.0.0
+requests==2.32.3

--- a/lite/api/verifier.py
+++ b/lite/api/verifier.py
@@ -1,0 +1,218 @@
+"""One-shot verifier — cross-checks submissions against the canonical chain.
+
+Reads rows in `submissions` where `verified IS NULL`, queries archive-node-api
+GraphQL for the canonical blocks in the same height range, and updates each
+row with:
+
+- `verified=true` when the row's (height, state_hash) matches a canonical block
+- `verified=false` + `validation_error` set, otherwise
+- `block_creator` recording who actually produced the canonical block at that
+  height (NULL if no canonical block exists at that height yet)
+
+Designed to be invoked from a Kubernetes CronJob — runs once and exits. Safe
+to run concurrently or on overlapping windows; the WHERE clause makes the
+work idempotent.
+"""
+
+import logging
+import os
+import sys
+import time
+from typing import Dict, List, Optional, Tuple
+
+import psycopg2
+import psycopg2.extras
+import requests
+
+logging.basicConfig(
+    level=os.environ.get("LOG_LEVEL", "INFO"),
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+log = logging.getLogger("verifier")
+
+
+def env(name: str, default: Optional[str] = None) -> str:
+    val = os.environ.get(name, default)
+    if val is None:
+        log.error("Required env var %s is not set", name)
+        sys.exit(2)
+    return val
+
+
+ARCHIVE_URL = env("ARCHIVE_NODE_API_URL")
+BATCH_SIZE = int(os.environ.get("VERIFIER_BATCH_SIZE", "500"))
+HEIGHT_BUCKET = int(os.environ.get("VERIFIER_HEIGHT_BUCKET", "100"))
+GRAPHQL_TIMEOUT = int(os.environ.get("VERIFIER_GRAPHQL_TIMEOUT", "30"))
+MAX_BATCHES = int(os.environ.get("VERIFIER_MAX_BATCHES", "20"))
+
+
+def get_conn():
+    return psycopg2.connect(
+        host=env("POSTGRES_HOST"),
+        port=os.environ.get("POSTGRES_PORT", "5432"),
+        dbname=env("POSTGRES_DB"),
+        user=env("POSTGRES_USER"),
+        password=env("POSTGRES_PASSWORD"),
+        sslmode=os.environ.get("POSTGRES_SSLMODE", "disable"),
+        connect_timeout=int(os.environ.get("POSTGRES_CONNECT_TIMEOUT", "10")),
+    )
+
+
+def ensure_schema(conn) -> None:
+    """Add the block_creator column if it's missing. Idempotent."""
+    with conn.cursor() as cur:
+        cur.execute(
+            "ALTER TABLE submissions "
+            "ADD COLUMN IF NOT EXISTS block_creator TEXT"
+        )
+    conn.commit()
+
+
+def fetch_canonical_blocks(min_h: int, max_h: int) -> Dict[int, Dict[str, str]]:
+    """Returns {height: {stateHash: creator, ...}, ...} for the canonical chain
+    between [min_h, max_h] inclusive."""
+    query = """
+      query($from: Int!, $to: Int!) {
+        blocks(query: {blockHeight_gte: $from, blockHeight_lt: $to, canonical: true}) {
+          blockHeight
+          creator
+          stateHash
+        }
+      }
+    """
+    variables = {"from": min_h, "to": max_h + 1}
+    r = requests.post(
+        ARCHIVE_URL,
+        json={"query": query, "variables": variables},
+        timeout=GRAPHQL_TIMEOUT,
+    )
+    r.raise_for_status()
+    body = r.json()
+    if "errors" in body:
+        raise RuntimeError(f"GraphQL errors: {body['errors']}")
+    blocks = body.get("data", {}).get("blocks") or []
+    out: Dict[int, Dict[str, str]] = {}
+    for b in blocks:
+        out.setdefault(b["blockHeight"], {})[b["stateHash"]] = b["creator"]
+    return out
+
+
+def classify(row, blocks_at_height: Dict[str, str]) -> Tuple[bool, Optional[str], Optional[str]]:
+    """Return (verified, validation_error, block_creator) for one submission row."""
+    if not blocks_at_height:
+        return False, "no-canonical-block-at-height", None
+    state_hash = row["state_hash"]
+    creator = blocks_at_height.get(state_hash)
+    if creator is not None:
+        return True, None, creator
+    return False, "state-hash-not-on-canonical-chain", None
+
+
+def process_batch() -> int:
+    """Process one batch of unverified rows. Returns rows updated."""
+    with get_conn() as conn:
+        ensure_schema(conn)
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT id, submitter, state_hash, height
+                FROM submissions
+                WHERE verified IS NULL
+                  AND state_hash IS NOT NULL
+                  AND height IS NOT NULL
+                ORDER BY height ASC
+                LIMIT %s
+                """,
+                (BATCH_SIZE,),
+            )
+            rows = cur.fetchall()
+        if not rows:
+            return 0
+
+        min_h = min(r["height"] for r in rows)
+        max_h = max(r["height"] for r in rows)
+        log.info(
+            "Fetched %d unverified rows, height range [%d, %d]",
+            len(rows),
+            min_h,
+            max_h,
+        )
+
+        canonical: Dict[int, Dict[str, str]] = {}
+        h = min_h
+        while h <= max_h:
+            window_end = min(h + HEIGHT_BUCKET - 1, max_h)
+            window = fetch_canonical_blocks(h, window_end)
+            canonical.update(window)
+            log.info(
+                "Archive returned %d canonical blocks for [%d, %d]",
+                sum(len(v) for v in window.values()),
+                h,
+                window_end,
+            )
+            h = window_end + 1
+
+        updates: List[Tuple[bool, Optional[str], Optional[str], int]] = []
+        verified_count = 0
+        unverified_count = 0
+        for row in rows:
+            verified, err, creator = classify(row, canonical.get(row["height"], {}))
+            updates.append((verified, err, creator, row["id"]))
+            if verified:
+                verified_count += 1
+            else:
+                unverified_count += 1
+
+        with conn.cursor() as cur:
+            psycopg2.extras.execute_batch(
+                cur,
+                """
+                UPDATE submissions
+                SET verified = %s,
+                    validation_error = %s,
+                    block_creator = %s
+                WHERE id = %s
+                """,
+                updates,
+                page_size=500,
+            )
+        conn.commit()
+        log.info(
+            "Batch complete: %d verified, %d unverified",
+            verified_count,
+            unverified_count,
+        )
+        return len(updates)
+
+
+def main() -> int:
+    log.info(
+        "verifier starting (archive=%s batch=%d bucket=%d max_batches=%d)",
+        ARCHIVE_URL,
+        BATCH_SIZE,
+        HEIGHT_BUCKET,
+        MAX_BATCHES,
+    )
+    total = 0
+    for i in range(MAX_BATCHES):
+        try:
+            n = process_batch()
+        except Exception:
+            log.exception("Batch %d failed", i + 1)
+            return 1
+        if n == 0:
+            log.info("No more unverified rows; exiting after %d updates", total)
+            break
+        total += n
+        time.sleep(1)
+    else:
+        log.info(
+            "Hit MAX_BATCHES=%d; updated %d rows this run, more remain for next run",
+            MAX_BATCHES,
+            total,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lite/run-tests.sh
+++ b/lite/run-tests.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Run lite/ unit tests. Invoked locally and by the lite-image CI workflow.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+VENV="${LITE_VENV:-.venv}"
+PYTHON_BIN="${PYTHON_BIN:-$(command -v python3.11 || command -v python3.12 || command -v python3)}"
+
+if [ ! -d "$VENV" ]; then
+  "$PYTHON_BIN" -m venv "$VENV"
+fi
+
+# shellcheck source=/dev/null
+source "$VENV/bin/activate"
+
+python3 -m pip install --quiet --upgrade pip
+python3 -m pip install --quiet -r api/requirements-dev.txt
+
+python3 -m pytest tests/ -v

--- a/lite/tests/conftest.py
+++ b/lite/tests/conftest.py
@@ -1,0 +1,12 @@
+import os
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "api"))
+
+os.environ.setdefault("POSTGRES_HOST", "127.0.0.1")
+os.environ.setdefault("POSTGRES_DB", "test")
+os.environ.setdefault("POSTGRES_USER", "test")
+os.environ.setdefault("POSTGRES_PASSWORD", "test")
+os.environ.setdefault("ARCHIVE_NODE_API_URL", "http://archive.test/graphql")

--- a/lite/tests/test_app.py
+++ b/lite/tests/test_app.py
@@ -1,0 +1,133 @@
+"""Unit tests for the navigator API."""
+
+import os
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+import app as appmod
+
+
+def _mock_conn(rows):
+    """Build a context-managing mock that mimics psycopg2 connection+cursor."""
+    cur = MagicMock()
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=False)
+    cur.fetchall.return_value = rows
+    cur.execute = MagicMock()
+    conn = MagicMock()
+    conn.__enter__ = MagicMock(return_value=conn)
+    conn.__exit__ = MagicMock(return_value=False)
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+@pytest.fixture
+def client(monkeypatch):
+    appmod.app.config.update(TESTING=True)
+    monkeypatch.delenv("WHITELIST", raising=False)
+    return appmod.app.test_client()
+
+
+def test_healthz_ok(client, monkeypatch):
+    conn, _ = _mock_conn([(1,)])
+    monkeypatch.setattr(appmod, "get_conn", lambda: conn)
+    resp = client.get("/healthz")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"status": "ok"}
+
+
+def test_healthz_db_error(client, monkeypatch):
+    def boom():
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(appmod, "get_conn", boom)
+    resp = client.get("/healthz")
+    assert resp.status_code == 500
+    body = resp.get_json()
+    assert body["status"] == "error"
+    assert "db down" in body["error"]
+
+
+def test_submitters_returns_rows(client, monkeypatch):
+    rows = [
+        {
+            "submitter": "B62qA",
+            "submissions": 10,
+            "last_seen": datetime(2026, 5, 12, 10, 0, 0),
+            "first_seen": datetime(2026, 5, 12, 9, 0, 0),
+            "valid": 9,
+            "invalid": 1,
+        }
+    ]
+    conn, cur = _mock_conn(rows)
+    monkeypatch.setattr(appmod, "get_conn", lambda: conn)
+
+    resp = client.get("/api/submitters")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data) == 1
+    assert data[0]["submitter"] == "B62qA"
+    assert data[0]["last_seen"] == "2026-05-12T10:00:00"
+
+    sql, params = cur.execute.call_args[0]
+    assert "GROUP BY submitter" in sql
+    assert params == []
+
+
+def test_submitters_whitelist_filters(client, monkeypatch):
+    monkeypatch.setenv("WHITELIST", "B62qA, B62qB")
+    conn, cur = _mock_conn([])
+    monkeypatch.setattr(appmod, "get_conn", lambda: conn)
+
+    client.get("/api/submitters")
+    sql, params = cur.execute.call_args[0]
+    assert "submitter = ANY(%s)" in sql
+    assert params == [["B62qA", "B62qB"]]
+
+
+def test_submitter_detail(client, monkeypatch):
+    rows = [
+        {
+            "id": 1,
+            "submitted_at": datetime(2026, 5, 12, 10, 0, 0),
+            "block_hash": "3Nhash",
+            "state_hash": "3Nstate",
+            "parent": "3Nparent",
+            "height": 100,
+            "slot": 200,
+            "validation_error": None,
+            "verified": True,
+            "remote_addr": "1.2.3.4",
+            "peer_id": "peer",
+            "built_with_commit_sha": "abc",
+        }
+    ]
+    conn, _ = _mock_conn(rows)
+    monkeypatch.setattr(appmod, "get_conn", lambda: conn)
+
+    resp = client.get("/api/submitter/B62qA")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data[0]["height"] == 100
+    assert data[0]["submitted_at"] == "2026-05-12T10:00:00"
+
+
+def test_submitter_detail_blocked_by_whitelist(client, monkeypatch):
+    monkeypatch.setenv("WHITELIST", "B62qOther")
+    monkeypatch.setattr(appmod, "get_conn", lambda: _mock_conn([])[0])
+
+    resp = client.get("/api/submitter/B62qA")
+    assert resp.status_code == 404
+    assert resp.get_json() == {"error": "not in whitelist"}
+
+
+def test_summary(client, monkeypatch):
+    rows = [{"day": "2026-05-12", "submitter": "B62qA", "submissions": 5}]
+    conn, _ = _mock_conn(rows)
+    monkeypatch.setattr(appmod, "get_conn", lambda: conn)
+
+    resp = client.get("/api/summary")
+    assert resp.status_code == 200
+    assert resp.get_json() == rows

--- a/lite/tests/test_verifier.py
+++ b/lite/tests/test_verifier.py
@@ -1,0 +1,82 @@
+"""Unit tests for the verifier module."""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import verifier
+
+
+def test_classify_match():
+    row = {"state_hash": "3NHash", "height": 100, "submitter": "B62qSub"}
+    blocks = {"3NHash": "B62qCreator"}
+    verified, err, creator = verifier.classify(row, blocks)
+    assert verified is True
+    assert err is None
+    assert creator == "B62qCreator"
+
+
+def test_classify_state_hash_mismatch():
+    row = {"state_hash": "3NHashFake", "height": 100, "submitter": "B62qSub"}
+    blocks = {"3NHashReal": "B62qCreator"}
+    verified, err, creator = verifier.classify(row, blocks)
+    assert verified is False
+    assert err == "state-hash-not-on-canonical-chain"
+    assert creator is None
+
+
+def test_classify_empty_height_bucket():
+    row = {"state_hash": "3NHash", "height": 100, "submitter": "B62qSub"}
+    verified, err, creator = verifier.classify(row, {})
+    assert verified is False
+    assert err == "no-canonical-block-at-height"
+    assert creator is None
+
+
+def test_fetch_canonical_blocks_buckets_by_height(monkeypatch):
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "data": {
+            "blocks": [
+                {"blockHeight": 100, "stateHash": "h100a", "creator": "B62q1"},
+                {"blockHeight": 100, "stateHash": "h100b", "creator": "B62q2"},
+                {"blockHeight": 101, "stateHash": "h101", "creator": "B62q1"},
+            ]
+        }
+    }
+    mock_response.raise_for_status = MagicMock()
+    mock_post = MagicMock(return_value=mock_response)
+    monkeypatch.setattr(verifier.requests, "post", mock_post)
+
+    result = verifier.fetch_canonical_blocks(100, 101)
+    assert result == {
+        100: {"h100a": "B62q1", "h100b": "B62q2"},
+        101: {"h101": "B62q1"},
+    }
+    args, kwargs = mock_post.call_args
+    assert kwargs["json"]["variables"] == {"from": 100, "to": 102}
+
+
+def test_fetch_canonical_blocks_raises_on_graphql_errors(monkeypatch):
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"errors": [{"message": "boom"}]}
+    mock_response.raise_for_status = MagicMock()
+    monkeypatch.setattr(
+        verifier.requests, "post", MagicMock(return_value=mock_response)
+    )
+
+    try:
+        verifier.fetch_canonical_blocks(100, 101)
+    except RuntimeError as e:
+        assert "boom" in str(e)
+    else:
+        raise AssertionError("expected RuntimeError")
+
+
+def test_fetch_canonical_blocks_handles_empty_response(monkeypatch):
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"data": {"blocks": None}}
+    mock_response.raise_for_status = MagicMock()
+    monkeypatch.setattr(
+        verifier.requests, "post", MagicMock(return_value=mock_response)
+    )
+    assert verifier.fetch_canonical_blocks(100, 101) == {}


### PR DESCRIPTION
verifier.py: one-shot Python script (CronJob-friendly) that scans                                                                                                                           
  submissions where verified IS NULL, queries archive-node-api GraphQL                                                                                                                      
  for canonical blocks in the same height range, and updates each row's                                                                                                                       
  verified/validation_error/block_creator columns. Idempotent and                                                                                                                             
  height-windowed for bounded query cost.                                                                                                                                                     
                                                                                                                                                                                              
  Adds a 13-test suite (pytest) covering classify(), GraphQL handling,                                                                                                                        
  and the navigator API endpoints with mocked DB. lite/run-tests.sh                                                                                                                         
  provisions a venv and invokes pytest — locally and in CI.                                                                                                                                   
                                                                                                                                                                                              
  .github/workflows/lite-image.yml: new `test` job runs on every PR and                                                                                                                       
  on push to main; build-and-push now needs: test so red tests block the                                                                                                                      
  image. .gitignore: ignore lite/.venv.