### PR TITLE
feat(lite): chain-verified columns + uptime coverage endpoint

### DIFF
--- a/lite/api/app.py
+++ b/lite/api/app.py
@@ -8,7 +8,7 @@ env var filters every query to a set of submitter public keys.
 import os
 
 import psycopg2
-from flask import Flask, jsonify, send_from_directory
+from flask import Flask, jsonify, request, send_from_directory
 from psycopg2.extras import RealDictCursor
 
 WEB_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "web")
@@ -67,7 +67,12 @@ def submitters():
                MAX(submitted_at) AS last_seen,
                MIN(submitted_at) AS first_seen,
                COUNT(*) FILTER (WHERE validation_error IS NULL) AS valid,
-               COUNT(*) FILTER (WHERE validation_error IS NOT NULL) AS invalid
+               COUNT(*) FILTER (WHERE validation_error IS NOT NULL) AS invalid,
+               COUNT(*) FILTER (WHERE verified IS TRUE) AS chain_verified,
+               COUNT(*) FILTER (WHERE verified IS FALSE) AS chain_rejected,
+               COUNT(*) FILTER (WHERE verified IS NULL) AS chain_pending,
+               COUNT(*) FILTER (WHERE block_creator = submitter) AS blocks_produced,
+               MAX(height) AS max_height
         FROM submissions
         {where}
         GROUP BY submitter
@@ -79,6 +84,71 @@ def submitters():
     return jsonify(_row_dates_iso(rows, "last_seen", "first_seen"))
 
 
+@app.get("/api/uptime/<pubkey>")
+def uptime(pubkey):
+    keys = whitelist()
+    if keys is not None and pubkey not in keys:
+        return jsonify(error="not in whitelist"), 404
+    try:
+        window_hours = int(request.args.get("window", "24"))
+    except (TypeError, ValueError):
+        return jsonify(error="window must be an integer (hours)"), 400
+    window_hours = max(1, min(window_hours, 168))
+    bucket_minutes = int(request.args.get("bucket_minutes", "5"))
+    bucket_minutes = max(1, min(bucket_minutes, 60))
+
+    sql = """
+        WITH params AS (
+            SELECT NOW() AS now_at,
+                   NOW() - (%s || ' hours')::interval AS since_at,
+                   (%s || ' minutes')::interval AS bucket
+        ),
+        buckets AS (
+            SELECT generate_series(
+                date_trunc('minute', (SELECT since_at FROM params)),
+                date_trunc('minute', (SELECT now_at FROM params)),
+                (SELECT bucket FROM params)
+            ) AS bucket_start
+        ),
+        hits AS (
+            SELECT date_trunc('minute', submitted_at) -
+                   (EXTRACT(MINUTE FROM submitted_at)::int %% %s) * interval '1 minute'
+                   AS bucket_start,
+                   COUNT(*) AS submissions,
+                   COUNT(*) FILTER (WHERE verified IS TRUE) AS chain_verified
+            FROM submissions
+            WHERE submitter = %s AND submitted_at >= (SELECT since_at FROM params)
+            GROUP BY 1
+        )
+        SELECT buckets.bucket_start AS bucket_start,
+               COALESCE(hits.submissions, 0) AS submissions,
+               COALESCE(hits.chain_verified, 0) AS chain_verified
+        FROM buckets LEFT JOIN hits USING (bucket_start)
+        ORDER BY buckets.bucket_start ASC
+    """
+    with get_conn() as conn, conn.cursor(cursor_factory=RealDictCursor) as cur:
+        cur.execute(sql, (window_hours, bucket_minutes, bucket_minutes, pubkey))
+        rows = cur.fetchall()
+
+    total_buckets = len(rows)
+    hit_buckets = sum(1 for r in rows if r["submissions"] > 0)
+    verified_buckets = sum(1 for r in rows if r["chain_verified"] > 0)
+    coverage_pct = round(100.0 * hit_buckets / total_buckets, 2) if total_buckets else 0.0
+    verified_pct = round(100.0 * verified_buckets / total_buckets, 2) if total_buckets else 0.0
+
+    for r in rows:
+        if r["bucket_start"] is not None:
+            r["bucket_start"] = r["bucket_start"].isoformat()
+    return jsonify({
+        "pubkey": pubkey,
+        "window_hours": window_hours,
+        "bucket_minutes": bucket_minutes,
+        "coverage_pct": coverage_pct,
+        "chain_verified_pct": verified_pct,
+        "buckets": rows,
+    })
+
+
 @app.get("/api/submitter/<pubkey>")
 def submitter(pubkey):
     keys = whitelist()
@@ -86,8 +156,8 @@ def submitter(pubkey):
         return jsonify(error="not in whitelist"), 404
     sql = """
         SELECT id, submitted_at, block_hash, state_hash, parent,
-               height, slot, validation_error, verified, remote_addr,
-               peer_id, built_with_commit_sha
+               height, slot, validation_error, verified, block_creator,
+               remote_addr, peer_id, built_with_commit_sha
         FROM submissions
         WHERE submitter = %s
         ORDER BY submitted_at DESC

--- a/lite/tests/test_app.py
+++ b/lite/tests/test_app.py
@@ -131,3 +131,59 @@ def test_summary(client, monkeypatch):
     resp = client.get("/api/summary")
     assert resp.status_code == 200
     assert resp.get_json() == rows
+
+
+def test_uptime_returns_coverage(client, monkeypatch):
+    rows = [
+        {"bucket_start": datetime(2026, 5, 12, 9, 0, 0), "submissions": 1, "chain_verified": 1},
+        {"bucket_start": datetime(2026, 5, 12, 9, 5, 0), "submissions": 0, "chain_verified": 0},
+        {"bucket_start": datetime(2026, 5, 12, 9, 10, 0), "submissions": 2, "chain_verified": 0},
+        {"bucket_start": datetime(2026, 5, 12, 9, 15, 0), "submissions": 0, "chain_verified": 0},
+    ]
+    conn, cur = _mock_conn(rows)
+    monkeypatch.setattr(appmod, "get_conn", lambda: conn)
+
+    resp = client.get("/api/uptime/B62qA?window=1&bucket_minutes=5")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["pubkey"] == "B62qA"
+    assert data["window_hours"] == 1
+    assert data["bucket_minutes"] == 5
+    assert data["coverage_pct"] == 50.0  # 2 of 4 buckets had submissions
+    assert data["chain_verified_pct"] == 25.0  # 1 of 4 buckets had a verified one
+    assert data["buckets"][0]["bucket_start"] == "2026-05-12T09:00:00"
+
+    sql, params = cur.execute.call_args[0]
+    assert "generate_series" in sql
+    assert params == (1, 5, 5, "B62qA")
+
+
+def test_uptime_clamps_window(client, monkeypatch):
+    conn, _ = _mock_conn([])
+    monkeypatch.setattr(appmod, "get_conn", lambda: conn)
+
+    resp = client.get("/api/uptime/B62qA?window=9999")
+    assert resp.status_code == 200
+    assert resp.get_json()["window_hours"] == 168  # clamped to max
+
+    resp = client.get("/api/uptime/B62qA?window=0")
+    assert resp.status_code == 200
+    assert resp.get_json()["window_hours"] == 1  # clamped to min
+
+
+def test_uptime_invalid_window(client, monkeypatch):
+    conn, _ = _mock_conn([])
+    monkeypatch.setattr(appmod, "get_conn", lambda: conn)
+
+    resp = client.get("/api/uptime/B62qA?window=foo")
+    assert resp.status_code == 400
+    assert "window" in resp.get_json()["error"]
+
+
+def test_uptime_blocked_by_whitelist(client, monkeypatch):
+    monkeypatch.setenv("WHITELIST", "B62qOther")
+    monkeypatch.setattr(appmod, "get_conn", lambda: _mock_conn([])[0])
+
+    resp = client.get("/api/uptime/B62qA")
+    assert resp.status_code == 404
+    assert resp.get_json() == {"error": "not in whitelist"}

--- a/lite/web/app.js
+++ b/lite/web/app.js
@@ -22,6 +22,12 @@ function truncate(s, n = 12) {
   return s.length <= n ? s : `${s.slice(0, n)}…`;
 }
 
+function verifiedLabel(verified) {
+  if (verified === true) return '<span class="ok">✓</span>';
+  if (verified === false) return '<span class="bad">✗</span>';
+  return '<span class="muted">…</span>';
+}
+
 function renderList() {
   const sorted = [...cached].sort((a, b) => {
     const av = a[sortField], bv = b[sortField];
@@ -36,10 +42,12 @@ function renderList() {
     tr.innerHTML = `
       <td><a href="#" data-pk="${row.submitter}"><code>${truncate(row.submitter, 24)}</code></a></td>
       <td class="num">${row.submissions}</td>
-      <td class="num">${row.valid}</td>
-      <td class="num invalid">${row.invalid}</td>
+      <td class="num ok">${row.chain_verified ?? 0}</td>
+      <td class="num bad">${row.chain_rejected ?? 0}</td>
+      <td class="num muted">${row.chain_pending ?? 0}</td>
+      <td class="num">${row.blocks_produced ?? 0}</td>
+      <td class="num">${row.max_height ?? ""}</td>
       <td>${fmtDate(row.last_seen)}</td>
-      <td>${fmtDate(row.first_seen)}</td>
     `;
     tbody.appendChild(tr);
   }
@@ -59,26 +67,68 @@ async function loadList() {
   }
 }
 
+function drawSparkline(canvas, buckets) {
+  const ctx = canvas.getContext("2d");
+  const w = canvas.width;
+  const h = canvas.height;
+  ctx.clearRect(0, 0, w, h);
+  if (!buckets || buckets.length === 0) return;
+  const max = buckets.reduce((m, b) => Math.max(m, b.submissions), 1);
+  const barW = w / buckets.length;
+  for (let i = 0; i < buckets.length; i++) {
+    const b = buckets[i];
+    const ratio = b.submissions / max;
+    const barH = Math.max(1, ratio * (h - 4));
+    const x = i * barW;
+    const y = h - barH;
+    ctx.fillStyle = b.chain_verified > 0
+      ? "#1e8449"
+      : b.submissions > 0 ? "#f5b041" : "#dddddd";
+    ctx.fillRect(x + 0.5, y, Math.max(1, barW - 1), barH);
+  }
+}
+
+async function loadUptime(pubkey) {
+  try {
+    const data = await fetchJSON(
+      `/api/uptime/${encodeURIComponent(pubkey)}?window=24&bucket_minutes=15`,
+    );
+    $("#uptime-summary").innerHTML = `
+      Coverage (24h): <strong>${data.coverage_pct}%</strong>
+      &middot; On-chain: <strong>${data.chain_verified_pct}%</strong>
+      &middot; ${data.buckets.length} buckets of ${data.bucket_minutes} min
+    `;
+    drawSparkline($("#uptime-sparkline"), data.buckets);
+  } catch (e) {
+    $("#uptime-summary").textContent = `Uptime unavailable: ${e.message}`;
+  }
+}
+
 async function showDetail(pubkey) {
   detailBody.innerHTML = "";
   $("#detail-pubkey").textContent = pubkey;
   $("#detail").hidden = false;
   $("#list").hidden = true;
+  $("#uptime-summary").textContent = "Loading…";
+  loadUptime(pubkey);
   try {
     const rows = await fetchJSON(`/api/submitter/${encodeURIComponent(pubkey)}`);
     for (const r of rows) {
+      const isCreator = r.block_creator && r.block_creator === pubkey;
       const tr = document.createElement("tr");
       tr.innerHTML = `
         <td>${fmtDate(r.submitted_at)}</td>
         <td class="num">${r.height ?? ""}</td>
         <td class="num">${r.slot ?? ""}</td>
         <td><code>${truncate(r.block_hash || "", 20)}</code></td>
+        <td class="num">${verifiedLabel(r.verified)}</td>
+        <td><code>${isCreator ? "self" : truncate(r.block_creator || "", 20)}</code></td>
         <td>${r.validation_error || ""}</td>
       `;
       detailBody.appendChild(tr);
     }
   } catch (e) {
-    detailBody.innerHTML = `<tr><td colspan="5">Error: ${e.message}</td></tr>`;
+    detailBody.innerHTML = `<tr><td colspan="7">Error: ${e.message}</td></tr>`;
   }
 }
 

--- a/lite/web/index.html
+++ b/lite/web/index.html
@@ -23,10 +23,12 @@
           <tr>
             <th data-sort="submitter">Submitter</th>
             <th data-sort="submissions" class="num">Submissions</th>
-            <th data-sort="valid" class="num">Valid</th>
-            <th data-sort="invalid" class="num">Invalid</th>
+            <th data-sort="chain_verified" class="num" title="Submissions cross-checked against the canonical chain">On chain</th>
+            <th data-sort="chain_rejected" class="num" title="Signed submissions that don't match a canonical block at that height">Off chain</th>
+            <th data-sort="chain_pending" class="num" title="Awaiting the next verifier run">Pending</th>
+            <th data-sort="blocks_produced" class="num" title="Submissions where this BP was the canonical block creator">Blocks produced</th>
+            <th data-sort="max_height" class="num">Max height</th>
             <th data-sort="last_seen">Last seen</th>
-            <th data-sort="first_seen">First seen</th>
           </tr>
         </thead>
         <tbody></tbody>
@@ -38,6 +40,9 @@
     <section id="detail" hidden>
       <button id="back" type="button">&laquo; Back</button>
       <h2><code id="detail-pubkey"></code></h2>
+      <div id="uptime-summary" class="summary"></div>
+      <canvas id="uptime-sparkline" width="600" height="60" aria-label="Submission coverage over the last 24 hours"></canvas>
+      <h3>Recent submissions</h3>
       <table id="detail-rows">
         <thead>
           <tr>
@@ -45,6 +50,8 @@
             <th>Height</th>
             <th>Slot</th>
             <th>Block hash</th>
+            <th title="From chain cross-validation">Verified</th>
+            <th>Block creator</th>
             <th>Validation error</th>
           </tr>
         </thead>

--- a/lite/web/style.css
+++ b/lite/web/style.css
@@ -70,6 +70,27 @@ th:hover { background: #ececec; }
 
 td.num, th.num { text-align: right; }
 td.invalid { color: var(--bad); }
+td.ok, span.ok { color: var(--good); }
+td.bad, span.bad { color: var(--bad); }
+td.muted, span.muted { color: var(--muted); }
+
+.summary {
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: white;
+  margin-bottom: 12px;
+}
+
+canvas#uptime-sparkline {
+  display: block;
+  width: 100%;
+  max-width: 600px;
+  border: 1px solid var(--border);
+  background: white;
+  border-radius: 4px;
+  margin-bottom: 16px;
+}
 
 code {
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;


### PR DESCRIPTION
/api/submitters now returns chain_verified/chain_rejected/chain_pending/
  blocks_produced/max_height. New /api/uptime/<pubkey>?window=N&bucket_minutes=M                                                                                                                                                                              
  returns coverage % + on-chain % + bucket-by-bucket counts. UI renders                                                                                                                                                                                     
  the new columns and a 24h sparkline in the per-submitter detail view.                                                                                                                                                                                       
  +5 unit tests (17 total, all passing).