### PR TITLE
feat(lite): temporal best-effort chain verification + uptime SQL fix

### DIFF
--- a/lite/api/app.py
+++ b/lite/api/app.py
@@ -129,25 +129,20 @@ def uptime(pubkey):
                 date_trunc('minute', (SELECT now_at FROM params)),
                 (SELECT bucket FROM params)
             ) AS bucket_start
-        ),
-        hits AS (
-            SELECT date_trunc('minute', submitted_at) -
-                   (EXTRACT(MINUTE FROM submitted_at)::int %% %s) * interval '1 minute'
-                   AS bucket_start,
-                   COUNT(*) AS submissions,
-                   COUNT(*) FILTER (WHERE verified IS TRUE) AS chain_verified
-            FROM submissions
-            WHERE submitter = %s AND submitted_at >= (SELECT since_at FROM params)
-            GROUP BY 1
         )
-        SELECT buckets.bucket_start AS bucket_start,
-               COALESCE(hits.submissions, 0) AS submissions,
-               COALESCE(hits.chain_verified, 0) AS chain_verified
-        FROM buckets LEFT JOIN hits USING (bucket_start)
-        ORDER BY buckets.bucket_start ASC
+        SELECT b.bucket_start AS bucket_start,
+               COUNT(s.id) AS submissions,
+               COUNT(s.id) FILTER (WHERE s.verified IS TRUE) AS chain_verified
+        FROM buckets b
+        LEFT JOIN submissions s
+          ON s.submitter = %s
+         AND s.submitted_at >= b.bucket_start
+         AND s.submitted_at <  b.bucket_start + (SELECT bucket FROM params)
+        GROUP BY b.bucket_start
+        ORDER BY b.bucket_start ASC
     """
     with get_conn() as conn, conn.cursor(cursor_factory=RealDictCursor) as cur:
-        cur.execute(sql, (window_hours, bucket_minutes, bucket_minutes, pubkey))
+        cur.execute(sql, (window_hours, bucket_minutes, pubkey))
         rows = cur.fetchall()
 
     total_buckets = len(rows)

--- a/lite/api/app.py
+++ b/lite/api/app.py
@@ -91,8 +91,7 @@ def submitters():
                COUNT(*) FILTER (WHERE verified IS TRUE) AS chain_verified,
                COUNT(*) FILTER (WHERE verified IS FALSE) AS chain_rejected,
                COUNT(*) FILTER (WHERE verified IS NULL) AS chain_pending,
-               COUNT(*) FILTER (WHERE block_creator = submitter) AS blocks_produced,
-               MAX(height) AS max_height
+               COUNT(*) FILTER (WHERE block_creator = submitter) AS blocks_produced
         FROM submissions
         {where}
         GROUP BY submitter

--- a/lite/api/verifier.py
+++ b/lite/api/verifier.py
@@ -1,13 +1,26 @@
-"""One-shot verifier — cross-checks submissions against the canonical chain.
+"""One-shot best-effort verifier — cross-checks submissions against the
+canonical chain by temporal proximity.
 
-Reads rows in `submissions` where `verified IS NULL`, queries archive-node-api
-GraphQL for the canonical blocks in the same height range, and updates each
-row with:
+The uptime-service-backend does not extract state_hash / height / slot from
+the submitted binary payload, so we cannot match a submission to a specific
+block by hash. Instead, for each submission at time T we look up the
+canonical blocks in archive-node-api whose `dateTime` falls within a small
+window around T and classify the submission as:
 
-- `verified=true` when the row's (height, state_hash) matches a canonical block
-- `verified=false` + `validation_error` set, otherwise
-- `block_creator` recording who actually produced the canonical block at that
-  height (NULL if no canonical block exists at that height yet)
+- `verified=true`, `block_creator=submitter` — when a block in the window
+  was produced by the submitter (strong signal: self-produced).
+- `verified=true`, `block_creator=<creator>`, `validation_error="submission-near-canonical-not-by-self"`
+  — when blocks exist in the window but none were produced by the submitter
+  (weak signal: chain healthy, BP was observing).
+- `verified=false`, `validation_error="no-canonical-block-near-submission-time"`
+  — when no canonical block exists in the window (likely chain unhealthy at
+  that time, or the submission referred to a non-canonical fork).
+
+This is intentionally lossy: it cannot distinguish a real submission from a
+replay or a signed-but-fake submission. It only measures "did this BP submit
+near times when the chain was producing canonical blocks". For stricter
+verification, the upstream uptime-service-backend would need to extract the
+submission's state_hash and we'd switch to height-anchored lookups.
 
 Designed to be invoked from a Kubernetes CronJob — runs once and exits. Safe
 to run concurrently or on overlapping windows; the WHERE clause makes the
@@ -18,6 +31,7 @@ import logging
 import os
 import sys
 import time
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional, Tuple
 
 import psycopg2
@@ -41,7 +55,7 @@ def env(name: str, default: Optional[str] = None) -> str:
 
 ARCHIVE_URL = env("ARCHIVE_NODE_API_URL")
 BATCH_SIZE = int(os.environ.get("VERIFIER_BATCH_SIZE", "500"))
-HEIGHT_BUCKET = int(os.environ.get("VERIFIER_HEIGHT_BUCKET", "100"))
+MATCH_WINDOW_SEC = int(os.environ.get("VERIFIER_MATCH_WINDOW_SEC", "90"))
 GRAPHQL_TIMEOUT = int(os.environ.get("VERIFIER_GRAPHQL_TIMEOUT", "30"))
 MAX_BATCHES = int(os.environ.get("VERIFIER_MAX_BATCHES", "20"))
 
@@ -68,19 +82,38 @@ def ensure_schema(conn) -> None:
     conn.commit()
 
 
-def fetch_canonical_blocks(min_h: int, max_h: int) -> Dict[int, Dict[str, str]]:
-    """Returns {height: {stateHash: creator, ...}, ...} for the canonical chain
-    between [min_h, max_h] inclusive."""
+def _to_utc(dt: datetime) -> datetime:
+    """Treat naive timestamps as UTC; convert aware ones to UTC."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _iso_z(dt: datetime) -> str:
+    """ISO 8601 with explicit Z suffix, what archive-node-api expects."""
+    return _to_utc(dt).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def fetch_canonical_blocks(start: datetime, end: datetime) -> List[Dict]:
+    """Return canonical blocks whose dateTime is in [start, end).
+
+    Each entry: {"blockHeight": int, "creator": str, "stateHash": str,
+                 "dateTime": datetime (UTC, aware)}.
+
+    archive-node-api returns dateTime as a string of unix-millis or ISO; we
+    parse defensively.
+    """
     query = """
-      query($from: Int!, $to: Int!) {
-        blocks(query: {blockHeight_gte: $from, blockHeight_lt: $to, canonical: true}) {
+      query($from: DateTime!, $to: DateTime!) {
+        blocks(query: {dateTime_gte: $from, dateTime_lt: $to, canonical: true}) {
           blockHeight
           creator
           stateHash
+          dateTime
         }
       }
     """
-    variables = {"from": min_h, "to": max_h + 1}
+    variables = {"from": _iso_z(start), "to": _iso_z(end)}
     r = requests.post(
         ARCHIVE_URL,
         json={"query": query, "variables": variables},
@@ -90,22 +123,48 @@ def fetch_canonical_blocks(min_h: int, max_h: int) -> Dict[int, Dict[str, str]]:
     body = r.json()
     if "errors" in body:
         raise RuntimeError(f"GraphQL errors: {body['errors']}")
-    blocks = body.get("data", {}).get("blocks") or []
-    out: Dict[int, Dict[str, str]] = {}
-    for b in blocks:
-        out.setdefault(b["blockHeight"], {})[b["stateHash"]] = b["creator"]
-    return out
+    raw = body.get("data", {}).get("blocks") or []
+    parsed: List[Dict] = []
+    for b in raw:
+        b["dateTime"] = _parse_archive_datetime(b["dateTime"])
+        parsed.append(b)
+    return parsed
 
 
-def classify(row, blocks_at_height: Dict[str, str]) -> Tuple[bool, Optional[str], Optional[str]]:
-    """Return (verified, validation_error, block_creator) for one submission row."""
-    if not blocks_at_height:
-        return False, "no-canonical-block-at-height", None
-    state_hash = row["state_hash"]
-    creator = blocks_at_height.get(state_hash)
-    if creator is not None:
-        return True, None, creator
-    return False, "state-hash-not-on-canonical-chain", None
+def _parse_archive_datetime(value) -> datetime:
+    """archive-node-api returns dateTime as either ISO string or unix-millis
+    string. Handle both."""
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(value / 1000.0, tz=timezone.utc)
+    s = str(value)
+    if s.isdigit():
+        return datetime.fromtimestamp(int(s) / 1000.0, tz=timezone.utc)
+    # ISO 8601 — replace trailing Z with +00:00 for fromisoformat
+    s = s.replace("Z", "+00:00")
+    return datetime.fromisoformat(s)
+
+
+def classify(
+    row,
+    blocks: List[Dict],
+    window: timedelta,
+) -> Tuple[bool, Optional[str], Optional[str]]:
+    """Return (verified, validation_error, block_creator) for one row.
+
+    Blocks must already be filtered to canonical blocks anywhere near this
+    row's submitted_at; we narrow to the window here.
+    """
+    submitted = _to_utc(row["submitted_at"])
+    lo, hi = submitted - window, submitted + window
+    nearby = [b for b in blocks if lo <= b["dateTime"] < hi]
+    if not nearby:
+        return False, "no-canonical-block-near-submission-time", None
+    self_blocks = [b for b in nearby if b["creator"] == row["submitter"]]
+    if self_blocks:
+        return True, None, row["submitter"]
+    # Pick the temporally closest block's creator for context
+    closest = min(nearby, key=lambda b: abs(b["dateTime"] - submitted))
+    return True, "submission-near-canonical-not-by-self", closest["creator"]
 
 
 def process_batch() -> int:
@@ -115,12 +174,11 @@ def process_batch() -> int:
         with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
             cur.execute(
                 """
-                SELECT id, submitter, state_hash, height
+                SELECT id, submitter, submitted_at
                 FROM submissions
                 WHERE verified IS NULL
-                  AND state_hash IS NOT NULL
-                  AND height IS NOT NULL
-                ORDER BY height ASC
+                  AND submitted_at IS NOT NULL
+                ORDER BY submitted_at ASC
                 LIMIT %s
                 """,
                 (BATCH_SIZE,),
@@ -129,39 +187,30 @@ def process_batch() -> int:
         if not rows:
             return 0
 
-        min_h = min(r["height"] for r in rows)
-        max_h = max(r["height"] for r in rows)
+        window = timedelta(seconds=MATCH_WINDOW_SEC)
+        min_t = _to_utc(min(r["submitted_at"] for r in rows)) - window
+        max_t = _to_utc(max(r["submitted_at"] for r in rows)) + window
         log.info(
-            "Fetched %d unverified rows, height range [%d, %d]",
+            "Fetched %d unverified rows, fetching canonical blocks for [%s, %s)",
             len(rows),
-            min_h,
-            max_h,
+            min_t.isoformat(),
+            max_t.isoformat(),
         )
 
-        canonical: Dict[int, Dict[str, str]] = {}
-        h = min_h
-        while h <= max_h:
-            window_end = min(h + HEIGHT_BUCKET - 1, max_h)
-            window = fetch_canonical_blocks(h, window_end)
-            canonical.update(window)
-            log.info(
-                "Archive returned %d canonical blocks for [%d, %d]",
-                sum(len(v) for v in window.values()),
-                h,
-                window_end,
-            )
-            h = window_end + 1
+        blocks = fetch_canonical_blocks(min_t, max_t)
+        log.info("Archive returned %d canonical blocks in the window", len(blocks))
 
         updates: List[Tuple[bool, Optional[str], Optional[str], int]] = []
-        verified_count = 0
-        unverified_count = 0
+        counts = {"verified_self": 0, "verified_near": 0, "rejected": 0}
         for row in rows:
-            verified, err, creator = classify(row, canonical.get(row["height"], {}))
+            verified, err, creator = classify(row, blocks, window)
             updates.append((verified, err, creator, row["id"]))
-            if verified:
-                verified_count += 1
+            if verified and err is None:
+                counts["verified_self"] += 1
+            elif verified:
+                counts["verified_near"] += 1
             else:
-                unverified_count += 1
+                counts["rejected"] += 1
 
         with conn.cursor() as cur:
             psycopg2.extras.execute_batch(
@@ -178,19 +227,19 @@ def process_batch() -> int:
             )
         conn.commit()
         log.info(
-            "Batch complete: %d verified, %d unverified",
-            verified_count,
-            unverified_count,
+            "Batch complete: %(verified_self)d self-produced, "
+            "%(verified_near)d near-canonical, %(rejected)d rejected",
+            counts,
         )
         return len(updates)
 
 
 def main() -> int:
     log.info(
-        "verifier starting (archive=%s batch=%d bucket=%d max_batches=%d)",
+        "verifier starting (archive=%s batch=%d match_window_sec=%d max_batches=%d)",
         ARCHIVE_URL,
         BATCH_SIZE,
-        HEIGHT_BUCKET,
+        MATCH_WINDOW_SEC,
         MAX_BATCHES,
     )
     total = 0

--- a/lite/tests/test_app.py
+++ b/lite/tests/test_app.py
@@ -156,7 +156,8 @@ def test_uptime_returns_coverage(client, monkeypatch):
     sql, params = cur.execute.call_args[0]
     assert "generate_series" in sql
     assert "LOCALTIMESTAMP" in sql
-    assert params == (1, 5, 5, "B62qA")
+    assert "LEFT JOIN submissions" in sql
+    assert params == (1, 5, "B62qA")
 
 
 def test_uptime_clamps_window(client, monkeypatch):

--- a/lite/tests/test_verifier.py
+++ b/lite/tests/test_verifier.py
@@ -1,45 +1,97 @@
 """Unit tests for the verifier module."""
 
-import sys
-from unittest.mock import MagicMock, patch
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
 
 import verifier
 
 
-def test_classify_match():
-    row = {"state_hash": "3NHash", "height": 100, "submitter": "B62qSub"}
-    blocks = {"3NHash": "B62qCreator"}
-    verified, err, creator = verifier.classify(row, blocks)
+def _block(height, creator, ts, state_hash="3Nh"):
+    return {
+        "blockHeight": height,
+        "creator": creator,
+        "stateHash": state_hash,
+        "dateTime": ts,
+    }
+
+
+WINDOW = timedelta(seconds=90)
+
+
+def test_classify_self_produced():
+    submitted = datetime(2026, 5, 12, 11, 36, 30, tzinfo=timezone.utc)
+    row = {"submitter": "B62qA", "submitted_at": submitted}
+    blocks = [_block(100, "B62qA", submitted - timedelta(seconds=10))]
+    verified, err, creator = verifier.classify(row, blocks, WINDOW)
     assert verified is True
     assert err is None
-    assert creator == "B62qCreator"
+    assert creator == "B62qA"
 
 
-def test_classify_state_hash_mismatch():
-    row = {"state_hash": "3NHashFake", "height": 100, "submitter": "B62qSub"}
-    blocks = {"3NHashReal": "B62qCreator"}
-    verified, err, creator = verifier.classify(row, blocks)
+def test_classify_near_canonical_other_creator():
+    submitted = datetime(2026, 5, 12, 11, 36, 30, tzinfo=timezone.utc)
+    row = {"submitter": "B62qA", "submitted_at": submitted}
+    blocks = [
+        _block(100, "B62qZ", submitted - timedelta(seconds=60)),
+        _block(101, "B62qY", submitted + timedelta(seconds=20)),
+    ]
+    verified, err, creator = verifier.classify(row, blocks, WINDOW)
+    assert verified is True
+    assert err == "submission-near-canonical-not-by-self"
+    # The temporally closest block's creator is reported
+    assert creator == "B62qY"
+
+
+def test_classify_no_canonical_in_window():
+    submitted = datetime(2026, 5, 12, 11, 36, 30, tzinfo=timezone.utc)
+    row = {"submitter": "B62qA", "submitted_at": submitted}
+    # Block is way outside the 90s window
+    blocks = [_block(100, "B62qZ", submitted - timedelta(minutes=20))]
+    verified, err, creator = verifier.classify(row, blocks, WINDOW)
     assert verified is False
-    assert err == "state-hash-not-on-canonical-chain"
+    assert err == "no-canonical-block-near-submission-time"
     assert creator is None
 
 
-def test_classify_empty_height_bucket():
-    row = {"state_hash": "3NHash", "height": 100, "submitter": "B62qSub"}
-    verified, err, creator = verifier.classify(row, {})
-    assert verified is False
-    assert err == "no-canonical-block-at-height"
-    assert creator is None
+def test_classify_naive_submitted_at_treated_as_utc():
+    naive = datetime(2026, 5, 12, 11, 36, 30)  # no tzinfo
+    row = {"submitter": "B62qA", "submitted_at": naive}
+    blocks = [_block(100, "B62qA",
+                    datetime(2026, 5, 12, 11, 36, 25, tzinfo=timezone.utc))]
+    verified, err, creator = verifier.classify(row, blocks, WINDOW)
+    assert verified is True
+    assert err is None
+    assert creator == "B62qA"
 
 
-def test_fetch_canonical_blocks_buckets_by_height(monkeypatch):
+def test_parse_archive_datetime_unix_millis_int():
+    target = datetime(2026, 5, 12, 11, 32, 0, tzinfo=timezone.utc)
+    millis = int(target.timestamp() * 1000)
+    assert verifier._parse_archive_datetime(millis) == target
+
+
+def test_parse_archive_datetime_unix_millis_string():
+    target = datetime(2026, 5, 12, 11, 32, 0, tzinfo=timezone.utc)
+    millis = str(int(target.timestamp() * 1000))
+    assert verifier._parse_archive_datetime(millis) == target
+
+
+def test_parse_archive_datetime_iso():
+    ts = verifier._parse_archive_datetime("2026-05-12T11:32:00Z")
+    assert ts == datetime(2026, 5, 12, 11, 32, 0, tzinfo=timezone.utc)
+
+
+def test_fetch_canonical_blocks_passes_iso_window(monkeypatch):
     mock_response = MagicMock()
     mock_response.json.return_value = {
         "data": {
             "blocks": [
-                {"blockHeight": 100, "stateHash": "h100a", "creator": "B62q1"},
-                {"blockHeight": 100, "stateHash": "h100b", "creator": "B62q2"},
-                {"blockHeight": 101, "stateHash": "h101", "creator": "B62q1"},
+                {
+                    "blockHeight": 100,
+                    "creator": "B62qA",
+                    "stateHash": "3Nh",
+                    "dateTime": "2026-05-12T11:32:00.000Z",
+                }
             ]
         }
     }
@@ -47,13 +99,21 @@ def test_fetch_canonical_blocks_buckets_by_height(monkeypatch):
     mock_post = MagicMock(return_value=mock_response)
     monkeypatch.setattr(verifier.requests, "post", mock_post)
 
-    result = verifier.fetch_canonical_blocks(100, 101)
-    assert result == {
-        100: {"h100a": "B62q1", "h100b": "B62q2"},
-        101: {"h101": "B62q1"},
-    }
-    args, kwargs = mock_post.call_args
-    assert kwargs["json"]["variables"] == {"from": 100, "to": 102}
+    start = datetime(2026, 5, 12, 11, 30, tzinfo=timezone.utc)
+    end = datetime(2026, 5, 12, 11, 40, tzinfo=timezone.utc)
+    blocks = verifier.fetch_canonical_blocks(start, end)
+    assert len(blocks) == 1
+    assert blocks[0]["blockHeight"] == 100
+    assert blocks[0]["creator"] == "B62qA"
+    assert blocks[0]["dateTime"] == datetime(
+        2026, 5, 12, 11, 32, tzinfo=timezone.utc
+    )
+
+    _, kwargs = mock_post.call_args
+    variables = kwargs["json"]["variables"]
+    assert variables["from"].startswith("2026-05-12T11:30:00")
+    assert variables["from"].endswith("Z")
+    assert variables["to"].startswith("2026-05-12T11:40:00")
 
 
 def test_fetch_canonical_blocks_raises_on_graphql_errors(monkeypatch):
@@ -63,20 +123,12 @@ def test_fetch_canonical_blocks_raises_on_graphql_errors(monkeypatch):
     monkeypatch.setattr(
         verifier.requests, "post", MagicMock(return_value=mock_response)
     )
-
     try:
-        verifier.fetch_canonical_blocks(100, 101)
+        verifier.fetch_canonical_blocks(
+            datetime(2026, 5, 12, tzinfo=timezone.utc),
+            datetime(2026, 5, 13, tzinfo=timezone.utc),
+        )
     except RuntimeError as e:
         assert "boom" in str(e)
     else:
         raise AssertionError("expected RuntimeError")
-
-
-def test_fetch_canonical_blocks_handles_empty_response(monkeypatch):
-    mock_response = MagicMock()
-    mock_response.json.return_value = {"data": {"blocks": None}}
-    mock_response.raise_for_status = MagicMock()
-    monkeypatch.setattr(
-        verifier.requests, "post", MagicMock(return_value=mock_response)
-    )
-    assert verifier.fetch_canonical_blocks(100, 101) == {}

--- a/lite/web/app.js
+++ b/lite/web/app.js
@@ -46,7 +46,6 @@ function renderList() {
       <td class="num bad">${row.chain_rejected ?? 0}</td>
       <td class="num muted">${row.chain_pending ?? 0}</td>
       <td class="num">${row.blocks_produced ?? 0}</td>
-      <td class="num">${row.max_height ?? ""}</td>
       <td>${fmtDate(row.last_seen)}</td>
     `;
     tbody.appendChild(tr);
@@ -118,9 +117,7 @@ async function showDetail(pubkey) {
       const tr = document.createElement("tr");
       tr.innerHTML = `
         <td>${fmtDate(r.submitted_at)}</td>
-        <td class="num">${r.height ?? ""}</td>
-        <td class="num">${r.slot ?? ""}</td>
-        <td><code>${truncate(r.block_hash || "", 20)}</code></td>
+        <td><code>${truncate(r.block_hash || "", 24)}</code></td>
         <td class="num">${verifiedLabel(r.verified)}</td>
         <td><code>${isCreator ? "self" : truncate(r.block_creator || "", 20)}</code></td>
         <td>${r.validation_error || ""}</td>
@@ -128,7 +125,7 @@ async function showDetail(pubkey) {
       detailBody.appendChild(tr);
     }
   } catch (e) {
-    detailBody.innerHTML = `<tr><td colspan="7">Error: ${e.message}</td></tr>`;
+    detailBody.innerHTML = `<tr><td colspan="5">Error: ${e.message}</td></tr>`;
   }
 }
 

--- a/lite/web/index.html
+++ b/lite/web/index.html
@@ -23,11 +23,10 @@
           <tr>
             <th data-sort="submitter">Submitter</th>
             <th data-sort="submissions" class="num">Submissions</th>
-            <th data-sort="chain_verified" class="num" title="Submissions cross-checked against the canonical chain">On chain</th>
-            <th data-sort="chain_rejected" class="num" title="Signed submissions that don't match a canonical block at that height">Off chain</th>
+            <th data-sort="chain_verified" class="num" title="Submissions confirmed by a canonical block near the submission time">On chain</th>
+            <th data-sort="chain_rejected" class="num" title="Submissions with no canonical block in the matching window">Off chain</th>
             <th data-sort="chain_pending" class="num" title="Awaiting the next verifier run">Pending</th>
-            <th data-sort="blocks_produced" class="num" title="Submissions where this BP was the canonical block creator">Blocks produced</th>
-            <th data-sort="max_height" class="num">Max height</th>
+            <th data-sort="blocks_produced" class="num" title="Submissions where a canonical block in the window was created by the submitter">Self-produced</th>
             <th data-sort="last_seen">Last seen</th>
           </tr>
         </thead>
@@ -47,8 +46,6 @@
         <thead>
           <tr>
             <th>Submitted at</th>
-            <th>Height</th>
-            <th>Slot</th>
             <th>Block hash</th>
             <th title="From chain cross-validation">Verified</th>
             <th>Block creator</th>


### PR DESCRIPTION
verifier.py rewrite — uptime-service-backend doesn't extract                                                            
  state_hash/height from the submitted payload, so height-anchored                                                          
  lookups won't work. Switch to temporal matching: for each unverified                                                      
  submission, query archive-node-api for canonical blocks within ±90s                                                       
  of submitted_at. Classify as self-produced / near-canonical / rejected.                                                   
                                                                                                                            
  app.py: /api/submitters surfaces chain_verified/chain_rejected/                                                           
  chain_pending/blocks_produced derived from the verifier's writes.                                                         
  /api/uptime bucketing rewritten to use a range LEFT JOIN — no more                                                      
  alignment mismatch (previous version always returned 0% even when                                                         
  submissions existed in the window).                                                                                     
                                                                                                                            
  Web UI mirrors the new columns + sparkline tinted green when at least                                                   
  one submission in that bucket was chain-verified.

  Tests: 8 verifier tests cover self-produced / near-canonical / no-block
  classifications plus archive datetime parsing. 12 app tests cover the                                                     
  new endpoints. 20 total, all passing.