### PR TITLE
fix(verifier): query inBestChain instead of canonical

### DIFF
--- a/lite/api/verifier.py
+++ b/lite/api/verifier.py
@@ -1,20 +1,25 @@
 """One-shot best-effort verifier — cross-checks submissions against the
-canonical chain by temporal proximity.
+best chain by temporal proximity.
 
 The uptime-service-backend does not extract state_hash / height / slot from
 the submitted binary payload, so we cannot match a submission to a specific
 block by hash. Instead, for each submission at time T we look up the
-canonical blocks in archive-node-api whose `dateTime` falls within a small
+best-chain blocks in archive-node-api whose `dateTime` falls within a small
 window around T and classify the submission as:
+
+We query with `inBestChain: true` rather than `canonical: true` because
+canonical (= finalized k blocks deep) lags far behind the tip on a young
+testnet — at the time of writing, only the genesis block was canonical
+while the chain was at height ~235.
 
 - `verified=true`, `block_creator=submitter` — when a block in the window
   was produced by the submitter (strong signal: self-produced).
-- `verified=true`, `block_creator=<creator>`, `validation_error="submission-near-canonical-not-by-self"`
+- `verified=true`, `block_creator=<creator>`, `validation_error="submission-near-block-not-by-self"`
   — when blocks exist in the window but none were produced by the submitter
   (weak signal: chain healthy, BP was observing).
-- `verified=false`, `validation_error="no-canonical-block-near-submission-time"`
-  — when no canonical block exists in the window (likely chain unhealthy at
-  that time, or the submission referred to a non-canonical fork).
+- `verified=false`, `validation_error="no-block-near-submission-time"`
+  — when no best-chain block exists in the window (likely chain unhealthy at
+  that time, or the submission referred to a dropped fork).
 
 This is intentionally lossy: it cannot distinguish a real submission from a
 replay or a signed-but-fake submission. It only measures "did this BP submit
@@ -94,8 +99,8 @@ def _iso_z(dt: datetime) -> str:
     return _to_utc(dt).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
 
-def fetch_canonical_blocks(start: datetime, end: datetime) -> List[Dict]:
-    """Return canonical blocks whose dateTime is in [start, end).
+def fetch_best_chain_blocks(start: datetime, end: datetime) -> List[Dict]:
+    """Return best-chain blocks whose dateTime is in [start, end).
 
     Each entry: {"blockHeight": int, "creator": str, "stateHash": str,
                  "dateTime": datetime (UTC, aware)}.
@@ -105,7 +110,7 @@ def fetch_canonical_blocks(start: datetime, end: datetime) -> List[Dict]:
     """
     query = """
       query($from: DateTime!, $to: DateTime!) {
-        blocks(query: {dateTime_gte: $from, dateTime_lt: $to, canonical: true}) {
+        blocks(query: {dateTime_gte: $from, dateTime_lt: $to, inBestChain: true}) {
           blockHeight
           creator
           stateHash
@@ -151,20 +156,20 @@ def classify(
 ) -> Tuple[bool, Optional[str], Optional[str]]:
     """Return (verified, validation_error, block_creator) for one row.
 
-    Blocks must already be filtered to canonical blocks anywhere near this
+    Blocks must already be filtered to best-chain blocks anywhere near this
     row's submitted_at; we narrow to the window here.
     """
     submitted = _to_utc(row["submitted_at"])
     lo, hi = submitted - window, submitted + window
     nearby = [b for b in blocks if lo <= b["dateTime"] < hi]
     if not nearby:
-        return False, "no-canonical-block-near-submission-time", None
+        return False, "no-block-near-submission-time", None
     self_blocks = [b for b in nearby if b["creator"] == row["submitter"]]
     if self_blocks:
         return True, None, row["submitter"]
     # Pick the temporally closest block's creator for context
     closest = min(nearby, key=lambda b: abs(b["dateTime"] - submitted))
-    return True, "submission-near-canonical-not-by-self", closest["creator"]
+    return True, "submission-near-block-not-by-self", closest["creator"]
 
 
 def process_batch() -> int:
@@ -191,14 +196,14 @@ def process_batch() -> int:
         min_t = _to_utc(min(r["submitted_at"] for r in rows)) - window
         max_t = _to_utc(max(r["submitted_at"] for r in rows)) + window
         log.info(
-            "Fetched %d unverified rows, fetching canonical blocks for [%s, %s)",
+            "Fetched %d unverified rows, fetching best-chain blocks for [%s, %s)",
             len(rows),
             min_t.isoformat(),
             max_t.isoformat(),
         )
 
-        blocks = fetch_canonical_blocks(min_t, max_t)
-        log.info("Archive returned %d canonical blocks in the window", len(blocks))
+        blocks = fetch_best_chain_blocks(min_t, max_t)
+        log.info("Archive returned %d best-chain blocks in the window", len(blocks))
 
         updates: List[Tuple[bool, Optional[str], Optional[str], int]] = []
         counts = {"verified_self": 0, "verified_near": 0, "rejected": 0}

--- a/lite/tests/test_verifier.py
+++ b/lite/tests/test_verifier.py
@@ -37,7 +37,7 @@ def test_classify_near_canonical_other_creator():
     ]
     verified, err, creator = verifier.classify(row, blocks, WINDOW)
     assert verified is True
-    assert err == "submission-near-canonical-not-by-self"
+    assert err == "submission-near-block-not-by-self"
     # The temporally closest block's creator is reported
     assert creator == "B62qY"
 
@@ -49,7 +49,7 @@ def test_classify_no_canonical_in_window():
     blocks = [_block(100, "B62qZ", submitted - timedelta(minutes=20))]
     verified, err, creator = verifier.classify(row, blocks, WINDOW)
     assert verified is False
-    assert err == "no-canonical-block-near-submission-time"
+    assert err == "no-block-near-submission-time"
     assert creator is None
 
 
@@ -101,7 +101,7 @@ def test_fetch_canonical_blocks_passes_iso_window(monkeypatch):
 
     start = datetime(2026, 5, 12, 11, 30, tzinfo=timezone.utc)
     end = datetime(2026, 5, 12, 11, 40, tzinfo=timezone.utc)
-    blocks = verifier.fetch_canonical_blocks(start, end)
+    blocks = verifier.fetch_best_chain_blocks(start, end)
     assert len(blocks) == 1
     assert blocks[0]["blockHeight"] == 100
     assert blocks[0]["creator"] == "B62qA"
@@ -124,7 +124,7 @@ def test_fetch_canonical_blocks_raises_on_graphql_errors(monkeypatch):
         verifier.requests, "post", MagicMock(return_value=mock_response)
     )
     try:
-        verifier.fetch_canonical_blocks(
+        verifier.fetch_best_chain_blocks(
             datetime(2026, 5, 12, tzinfo=timezone.utc),
             datetime(2026, 5, 13, tzinfo=timezone.utc),
         )


### PR DESCRIPTION
Mina's k=290 finalization depth means archive-node-api's
  canonical: true filter returns only blocks at least 290 deep. On a
  young testnet (pre-mesa-auto at height ~235) that's just genesis —
  the verifier rejected all 19 submissions with
  "no-canonical-block-near-submission-time" despite the chain being
  healthy and producing blocks.

  Switch the query to inBestChain: true, which returns the current
  best-chain trace (canonical portion + the still-finalizing tip). This
  is a strict superset of canonical on mature chains, so no future
  change is needed once pre-mesa stabilizes and the older blocks become
  canonical.

  Renames: fetch_canonical_blocks -> fetch_best_chain_blocks; error
  labels switch from *-canonical-* to *-block-* to reflect the new
  semantics. Tests + module docstring updated.

  Trade-off: a block in best chain at verifier-run time could later be
  reorged out, leaving rows verified=true that strictly weren't on the
  finalized chain. Acceptable for uptime metrics (BP was working at the
  time); not appropriate for audit/payout flows, which should run a
  separate canonical-filtered pass over older data.