### PR TITLE
feat(lite): Export to CSV button + Node-24 CI bumps

### DIFF
--- a/.github/workflows/lite-image.yml
+++ b/.github/workflows/lite-image.yml
@@ -34,10 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip
@@ -55,7 +55,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Compute tag
         id: tag
@@ -86,17 +86,17 @@ jobs:
 
       - name: Log in to GHCR
         if: steps.tag.outputs.push == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build (and conditionally push)
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ./lite
           push: ${{ steps.tag.outputs.push }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: 🏷️ Generate Tag
         run: |
@@ -46,21 +46,21 @@ jobs:
           fi
 
       - name: 🔑 Log in to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🛠️ Build and Push Web Docker Image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: ./web
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}-${{ env.REPOSITORY_NAME_WEB }}:${{ env.TAG }}
 
       - name: 🛠️ Build and Push API Docker Image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: ./api
           push: true

--- a/lite/run-tests.sh
+++ b/lite/run-tests.sh
@@ -18,3 +18,12 @@ python3 -m pip install --quiet --upgrade pip
 python3 -m pip install --quiet -r api/requirements-dev.txt
 
 python3 -m pytest tests/ -v
+
+# JS tests for the client-side CSV helpers. ubuntu-latest GitHub runners
+# ship Node 20+ pre-installed, which provides the stable node:test runner.
+# Skip locally if node is missing rather than failing the whole script.
+if command -v node >/dev/null 2>&1; then
+  node --test tests/test_csv.js
+else
+  echo "WARN: node not found; skipping JS unit tests for csv.js."
+fi

--- a/lite/tests/test_csv.js
+++ b/lite/tests/test_csv.js
@@ -1,0 +1,105 @@
+// Unit tests for the pure CSV helpers shared by the lite leaderboard's
+// Export CSV button. Run via: node --test tests/test_csv.js
+// (also invoked by ./run-tests.sh after the pytest suite).
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+
+const { csvEscape, arrayToCSV, tsStamp } = require(
+  path.join(__dirname, "..", "web", "csv.js"),
+);
+
+const BOM = "﻿";
+
+test("csvEscape passes simple ASCII through unquoted", () => {
+  assert.equal(csvEscape("hello"), "hello");
+  assert.equal(csvEscape("B62qABCDEFGH"), "B62qABCDEFGH");
+});
+
+test("csvEscape treats null and undefined as empty strings", () => {
+  assert.equal(csvEscape(null), "");
+  assert.equal(csvEscape(undefined), "");
+});
+
+test("csvEscape stringifies numbers without quoting", () => {
+  assert.equal(csvEscape(0), "0");
+  assert.equal(csvEscape(42), "42");
+  assert.equal(csvEscape(3.14), "3.14");
+});
+
+test("csvEscape quotes values containing comma, double-quote, CR, LF", () => {
+  assert.equal(csvEscape("a,b"), '"a,b"');
+  assert.equal(csvEscape("line1\nline2"), '"line1\nline2"');
+  assert.equal(csvEscape("car\rriage"), '"car\rriage"');
+  assert.equal(csvEscape('she said "hi"'), '"she said ""hi"""');
+});
+
+test("arrayToCSV emits BOM, header, CRLF data rows, trailing CRLF", () => {
+  const rows = [{ a: 1, b: "x" }, { a: 2, b: "y" }];
+  const cols = [
+    { header: "a", key: "a" },
+    { header: "b", key: "b" },
+  ];
+  const csv = arrayToCSV(rows, cols);
+  assert.ok(csv.startsWith(BOM), "starts with UTF-8 BOM");
+  assert.equal(csv, BOM + "a,b\r\n1,x\r\n2,y\r\n");
+});
+
+test("arrayToCSV with empty rows produces just the header (plus BOM and trailing CRLF)", () => {
+  const cols = [{ header: "a", key: "a" }];
+  assert.equal(arrayToCSV([], cols), BOM + "a\r\n\r\n");
+});
+
+test("arrayToCSV supports derived columns via column.value()", () => {
+  const rows = [{ k: "A" }, { k: "B" }];
+  const cols = [
+    { header: "rank", value: (_row, i) => i + 1 },
+    { header: "k", key: "k" },
+  ];
+  assert.equal(arrayToCSV(rows, cols), BOM + "rank,k\r\n1,A\r\n2,B\r\n");
+});
+
+test("arrayToCSV preserves full untruncated public keys (the whole point of the export)", () => {
+  const fullKey = "B62qoooooooooooooooooooooooooooooooooooooooooooooooooo";
+  const rows = [{ submitter: fullKey, score: 100 }];
+  const cols = [
+    { header: "submitter", key: "submitter" },
+    { header: "score", key: "score" },
+  ];
+  const csv = arrayToCSV(rows, cols);
+  assert.ok(csv.includes(fullKey), "full key present in output");
+  assert.ok(!csv.includes("…"), "no truncation ellipsis in output");
+});
+
+test("arrayToCSV escapes commas inside string fields", () => {
+  const rows = [{ k: "B62qA", validation_error: "bad signature, retry" }];
+  const cols = [
+    { header: "k", key: "k" },
+    { header: "validation_error", key: "validation_error" },
+  ];
+  const csv = arrayToCSV(rows, cols);
+  assert.ok(csv.includes('"bad signature, retry"'));
+});
+
+test("arrayToCSV emits null/undefined fields as empty (not the literal string 'null')", () => {
+  const rows = [{ a: null, b: undefined, c: 0 }];
+  const cols = [
+    { header: "a", key: "a" },
+    { header: "b", key: "b" },
+    { header: "c", key: "c" },
+  ];
+  assert.equal(arrayToCSV(rows, cols), BOM + "a,b,c\r\n,,0\r\n");
+});
+
+test("arrayToCSV ISO timestamp fields pass through verbatim", () => {
+  // Server returns ISO strings via _row_dates_iso(...); confirm they survive untouched.
+  const rows = [{ ts: "2026-05-18T13:35:42" }];
+  const cols = [{ header: "ts", key: "ts" }];
+  const csv = arrayToCSV(rows, cols);
+  assert.ok(csv.includes("2026-05-18T13:35:42"));
+});
+
+test("tsStamp matches YYYYMMDD-HHMMSS shape", () => {
+  assert.match(tsStamp(), /^\d{8}-\d{6}$/);
+});

--- a/lite/web/app.js
+++ b/lite/web/app.js
@@ -216,6 +216,61 @@ document.querySelectorAll("nav.tabs .tab").forEach((btn) => {
 $("#back").addEventListener("click", hideDetail);
 $("#refresh").addEventListener("click", loadList);
 
+const SUBMITTERS_COLUMNS = [
+  { header: "submitter",       key: "submitter" },
+  { header: "submissions",     key: "submissions" },
+  { header: "chain_verified",  key: "chain_verified" },
+  { header: "chain_rejected",  key: "chain_rejected" },
+  { header: "chain_pending",   key: "chain_pending" },
+  { header: "blocks_produced", key: "blocks_produced" },
+  { header: "valid",           key: "valid" },
+  { header: "invalid",         key: "invalid" },
+  { header: "first_seen",      key: "first_seen" },
+  { header: "last_seen",       key: "last_seen" },
+];
+
+const LEADERBOARD_COLUMNS = [
+  { header: "rank",               value: (_r, i) => i + 1 },
+  { header: "block_producer_key", key: "block_producer_key" },
+  { header: "score",              key: "score" },
+  { header: "score_percent",      key: "score_percent" },
+];
+
+$("#export-csv").addEventListener("click", async () => {
+  const btn = $("#export-csv");
+  btn.disabled = true;
+  const prev = btn.textContent;
+  btn.textContent = "Exporting…";
+  try {
+    const days     = $("#lb-uptime-days").value || "90";
+    const interval = $("#lb-survey-min").value || "20";
+    const verified = $("#lb-require-verified").checked;
+    const lbURL = `/api/leaderboard?uptime_days=${days}` +
+                  `&survey_interval_minutes=${interval}` +
+                  `&require_verified=${verified}`;
+    const [submitters, lb] = await Promise.all([
+      fetchJSON("/api/submitters"),
+      fetchJSON(lbURL),
+    ]);
+    const stamp = tsStamp();
+    downloadCSV(
+      `submitters-${stamp}.csv`,
+      arrayToCSV(submitters, SUBMITTERS_COLUMNS),
+    );
+    setTimeout(() => {
+      downloadCSV(
+        `leaderboard-${days}d-${interval}m-${verified ? "verified" : "all"}-${stamp}.csv`,
+        arrayToCSV(lb.rows, LEADERBOARD_COLUMNS),
+      );
+    }, 150);
+  } catch (e) {
+    alert(`Export failed: ${e.message}`);
+  } finally {
+    btn.textContent = prev;
+    btn.disabled = false;
+  }
+});
+
 document.querySelectorAll("#submitters thead th").forEach((th) => {
   th.addEventListener("click", () => {
     const field = th.dataset.sort;

--- a/lite/web/csv.js
+++ b/lite/web/csv.js
@@ -1,0 +1,42 @@
+// Pure CSV utilities shared between the browser app and Node tests.
+// Loaded as a classic script in the browser (defines globals consumed by
+// app.js) and as a CommonJS module by node:test (via module.exports).
+
+function csvEscape(v) {
+  if (v == null) return "";
+  const s = String(v);
+  return /[",\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+function arrayToCSV(rows, columns) {
+  const header = columns.map(c => csvEscape(c.header)).join(",");
+  const body = rows.map((row, i) =>
+    columns.map(c => csvEscape(c.value ? c.value(row, i) : row[c.key])).join(",")
+  ).join("\r\n");
+  // UTF-8 BOM so Excel on Windows detects the encoding.
+  return "﻿" + header + "\r\n" + body + "\r\n";
+}
+
+function downloadCSV(filename, csv) {
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+
+function tsStamp() {
+  const d = new Date();
+  const pad = n => String(n).padStart(2, "0");
+  return `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}` +
+         `-${pad(d.getHours())}${pad(d.getMinutes())}${pad(d.getSeconds())}`;
+}
+
+if (typeof module !== "undefined" && module.exports) {
+  // downloadCSV is intentionally not exported (requires DOM + Blob).
+  module.exports = { csvEscape, arrayToCSV, tsStamp };
+}

--- a/lite/web/index.html
+++ b/lite/web/index.html
@@ -17,6 +17,7 @@
       <span id="submitter-count">—</span> submitters &middot;
       refreshed <span id="refreshed">—</span>
       <button id="refresh" type="button">Refresh</button>
+      <button id="export-csv" type="button" title="Download submitters.csv and leaderboard.csv">Export CSV</button>
     </div>
   </header>
 
@@ -91,6 +92,7 @@
     </section>
   </main>
 
+  <script src="/csv.js"></script>
   <script src="/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
* Add "Export CSV" button to the uptime-navigator-lite header. On click it fetches /api/submitters and /api/leaderboard fresh, builds two CSVs in the browser (UTF-8 BOM, CRLF, full untruncated public keys), and triggers two staggered downloads. Leaderboard filename embeds the active uptime_days, survey_interval_minutes, and require_verified params.

* Extract pure CSV helpers (csvEscape, arrayToCSV, downloadCSV, tsStamp) into lite/web/csv.js so they can be unit-tested from Node. Browser still gets them as globals via a classic <script> tag loaded before app.js.

* Add lite/tests/test_csv.js using the built-in node:test runner: 12 cases covering CSV escaping (commas, quotes, CR/LF, null/undefined), arrayToCSV output shape (BOM, CRLF, derived columns), full-key preservation, and the tsStamp YYYYMMDD-HHMMSS format. run-tests.sh now runs both pytest and node --test (with a graceful skip when node is missing locally).

* Bump GitHub Actions to the lowest Node-24-compatible majors to clear the Node-20 deprecation warnings:
    - actions/checkout v3/v4 -> v5
    - actions/setup-python v5 -> v6
    - docker/login-action v2/v3 -> v4
    - docker/setup-buildx-action v3 -> v4
    - docker/build-push-action v4/v5 -> v7 (v6 still on Node 20)